### PR TITLE
Hopefully fixes deaths logging to the DB

### DIFF
--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -131,7 +131,6 @@ CREATE TABLE `death` (
   `x_coord` smallint(5) unsigned NOT NULL,
   `y_coord` smallint(5) unsigned NOT NULL,
   `z_coord` smallint(5) unsigned NOT NULL,
-  `mapname` varchar(64) NOT NULL,
   `server_ip` int(10) unsigned NOT NULL,
   `server_port` smallint(5) unsigned NOT NULL,
   `round_id` int(11) NOT NULL,

--- a/code/controllers/subsystem/blackbox.dm
+++ b/code/controllers/subsystem/blackbox.dm
@@ -316,7 +316,7 @@ Versioning
 		return
 
 	var/datum/DBQuery/query_report_death = SSdbcore.NewQuery({"
-		INSERT INTO [format_table_name("death")] (pod, x_coord, y_coord, z_coord, mapname, server_ip, server_port, round_id, tod, job, special, name, byondkey, laname, lakey, bruteloss, fireloss, brainloss, oxyloss, toxloss, cloneloss, staminaloss, last_words, suicide)
+		INSERT INTO [format_table_name("death")] (pod, x_coord, y_coord, z_coord, server_ip, server_port, round_id, tod, job, special, name, byondkey, laname, lakey, bruteloss, fireloss, brainloss, oxyloss, toxloss, cloneloss, staminaloss, last_words, suicide)
 		VALUES (:pod, :x_coord, :y_coord, :z_coord, INET_ATON(:internet_address), :port, :round_id, :time, :job, :special, :name, :key, :laname, :lakey, :brute, :fire, :brain, :oxy, :tox, :clone, :stamina, :last_words, :suicide)
 	"}, list(
 		"name" = L.real_name,


### PR DESCRIPTION
Voidcrew doesn't use conventional maps, so this isn't really important

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes mapname from the sql query and database schema, as voidcrew doesn't use conventional maps, and I don't even know how I'd go about retrieving a mapname when we literally don't have one, and it didn't have the mapname being defined anyways, so it was inserting the wrong thing into the mapname column.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
I'm not completely certain this works, as I didn't set up a DB to test it, but you can't get much worse than "literally doesn't work in the first place"
## Why It's Good For The Game
Things functioning is good
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Deaths should now be properly logged to the database
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
