### PR TITLE
Makes shuttle windows deconstructible

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -6600,7 +6600,7 @@
 /turf/open/floor/plating,
 /area/centcom/evac)
 "aKP" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/centcom/evac)

--- a/_maps/shuttles/escape_pod/escape_pod_large.dmm
+++ b/_maps/shuttles/escape_pod/escape_pod_large.dmm
@@ -19,7 +19,7 @@
 /area/shuttle/pod_1)
 "u" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/shuttle/pod_1)
 "v" = (

--- a/_maps/shuttles/hunter/hunter_space_cop.dmm
+++ b/_maps/shuttles/hunter/hunter_space_cop.dmm
@@ -94,7 +94,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/hunter)
 "hJ" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/shuttle/hunter)

--- a/_maps/shuttles/ruin/ruin_solgov_exploration_pod.dmm
+++ b/_maps/shuttles/ruin/ruin_solgov_exploration_pod.dmm
@@ -3,7 +3,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "d" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "g" = (

--- a/_maps/shuttles/shiptest/liberty.dmm
+++ b/_maps/shuttles/shiptest/liberty.dmm
@@ -213,7 +213,7 @@
 	id = "pirateshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/security)
 "mg" = (
@@ -362,7 +362,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/security)
 "oo" = (
@@ -766,7 +766,7 @@
 	id = "pirateshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "zi" = (
@@ -1813,7 +1813,7 @@
 	id = "pirateshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "XJ" = (

--- a/_maps/shuttles/shiptest/rigoureux.dmm
+++ b/_maps/shuttles/shiptest/rigoureux.dmm
@@ -5,7 +5,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "aw" = (
@@ -68,7 +68,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -486,7 +486,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "ip" = (
@@ -898,7 +898,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/security)
 "mQ" = (
@@ -981,7 +981,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -2040,7 +2040,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/medical)
 "zF" = (
@@ -2447,7 +2447,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -2740,7 +2740,7 @@
 	name = "blast shutters"
 	},
 /obj/structure/curtain,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "Hn" = (
@@ -2997,7 +2997,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/construction)
 "KX" = (
@@ -3341,7 +3341,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "Pj" = (
@@ -3435,7 +3435,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/construction)
 "Qq" = (
@@ -3600,7 +3600,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "RE" = (
@@ -3819,7 +3819,7 @@
 	name = "blast shutters"
 	},
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "Uo" = (
@@ -3871,7 +3871,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/engineering)
 "Vj" = (
@@ -3954,7 +3954,7 @@
 	name = "blast shutters"
 	},
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/construction)
 "Wj" = (

--- a/_maps/shuttles/shiptest/rigoureux_d.dmm
+++ b/_maps/shuttles/shiptest/rigoureux_d.dmm
@@ -5,7 +5,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -97,7 +97,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#9ADEDE"
 	},
 /turf/open/floor/plating,
@@ -338,7 +338,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -536,7 +536,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#9ADEDE"
 	},
 /turf/open/floor/plating,
@@ -1014,7 +1014,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -1082,7 +1082,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#9ADEDE"
 	},
 /turf/open/floor/plating,
@@ -2204,7 +2204,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -2383,7 +2383,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#9ADEDE"
 	},
 /turf/open/floor/plating,
@@ -2997,7 +2997,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /obj/structure/curtain,
@@ -3283,7 +3283,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -3737,7 +3737,7 @@
 /obj/machinery/atmospherics/components/binary/pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -3883,7 +3883,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -4128,7 +4128,7 @@
 	name = "blast shutters"
 	},
 /obj/structure/grille,
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -4195,7 +4195,7 @@
 	id = "riggerwindows";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,
@@ -4284,7 +4284,7 @@
 	name = "blast shutters"
 	},
 /obj/structure/grille,
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#E58E2D"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/shiptest/scrapper_b.dmm
+++ b/_maps/shuttles/shiptest/scrapper_b.dmm
@@ -11,7 +11,7 @@
 /area/ship/crew/canteen)
 "ai" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	id = "externalbridgeshutter";
 	name = "blast shutters"
@@ -791,7 +791,7 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "lA" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,
@@ -2378,7 +2378,7 @@
 /turf/open/floor/pod/light,
 /area/ship/bridge)
 "Fz" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,
@@ -2525,7 +2525,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Hj" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,
@@ -2538,7 +2538,7 @@
 /area/ship/cargo)
 "Hs" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,
 /turf/open/floor/plating,
@@ -3895,7 +3895,7 @@
 /turf/open/floor/plating,
 /area/ship/engineering/atmospherics)
 "Wb" = (
-/obj/structure/window/shuttle/unanchored,
+/obj/structure/window/reinforced/shuttle/unanchored,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,
@@ -4097,7 +4097,7 @@
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Zs" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /obj/machinery/door/firedoor/window,
 /obj/structure/curtain/bounty,

--- a/_maps/shuttles/shiptest/voidcrew/Nanopill.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/Nanopill.dmm
@@ -3,7 +3,7 @@
 /turf/template_noop,
 /area/template_noop)
 "f" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/ship/bridge)

--- a/_maps/shuttles/shiptest/voidcrew/brilliant.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/brilliant.dmm
@@ -262,7 +262,7 @@
 /area/ship/bridge)
 "lc" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle{
+/obj/structure/window/reinforced/shuttle{
 	color = "#9ce9f6"
 	},
 /turf/open/floor/plating,

--- a/_maps/shuttles/shiptest/voidcrew/libertarian.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/libertarian.dmm
@@ -210,7 +210,7 @@
 	id = "ntlibshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/security)
 "mg" = (
@@ -352,7 +352,7 @@
 /obj/machinery/atmospherics/pipe/layer_manifold{
 	dir = 4
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor/shutters{
 	id = "ntlibshutters";
 	name = "blast shutters"
@@ -719,7 +719,7 @@
 	id = "ntlibshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew)
 "zi" = (
@@ -1704,7 +1704,7 @@
 	id = "ntlibshutters";
 	name = "blast shutters"
 	},
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "XJ" = (

--- a/_maps/shuttles/shiptest/voidcrew/nooper.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/nooper.dmm
@@ -924,7 +924,7 @@
 /area/ship/maintenance/aft)
 "WT" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "XT" = (

--- a/_maps/shuttles/shiptest/voidcrew/phalanx.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/phalanx.dmm
@@ -21,7 +21,7 @@
 /area/ship/cargo)
 "ap" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
 	id = "phpublicblastdoors"
 	},
@@ -1178,7 +1178,7 @@
 /area/ship/crew/chapel)
 "lM" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew/chapel)
 "lY" = (
@@ -1434,7 +1434,7 @@
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical/surgery)
 "pg" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/mineral/titanium/tiled/blue,
 /area/ship/medical/surgery)
@@ -1896,7 +1896,7 @@
 /area/ship/hallway/fore)
 "tn" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
 	id = "phbridgeblastdoors"
 	},
@@ -2320,7 +2320,7 @@
 /area/ship/crew/canteen)
 "yk" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/machinery/door/poddoor{
 	id = "phpublicblastdoors"
 	},
@@ -3396,7 +3396,7 @@
 /area/ship/science)
 "JL" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew/canteen)
 "JM" = (
@@ -3764,7 +3764,7 @@
 	},
 /area/ship/cargo)
 "NC" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/mineral/titanium/tiled/purple,
 /area/ship/science)

--- a/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
@@ -39,7 +39,7 @@
 /area/ship/crew/dorm)
 "dh" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "dm" = (
@@ -101,7 +101,7 @@
 /area/ship/hallway/central)
 "dS" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/crew/dorm)
 "eO" = (
@@ -1255,7 +1255,7 @@
 /area/ship/security/armory)
 "Zy" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "ZN" = (

--- a/_maps/shuttles/shiptest/voidcrew/trambullet.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/trambullet.dmm
@@ -150,7 +150,7 @@
 /area/ship/bridge)
 "x" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ship/bridge)
 "z" = (
@@ -199,7 +199,7 @@
 /area/ship/bridge)
 "I" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/docking_port/mobile{
 	can_move_docking_ports = 1;
 	dir = 8;

--- a/code/__DEFINES/icon_smoothing.dm
+++ b/code/__DEFINES/icon_smoothing.dm
@@ -93,7 +93,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_ABDUCTOR_WALLS S_OBJ(10) ///turf/closed/wall/mineral/abductor, /obj/structure/falsewall/abductor
 #define SMOOTH_GROUP_TITANIUM_WALLS S_OBJ(11) ///turf/closed/wall/mineral/titanium, /obj/structure/falsewall/titanium
 #define SMOOTH_GROUP_PLASTITANIUM_WALLS S_OBJ(13) ///turf/closed/wall/mineral/plastitanium, /obj/structure/falsewall/plastitanium
-#define SMOOTH_GROUP_SURVIVAL_TIANIUM_POD S_OBJ(14) ///turf/closed/wall/mineral/titanium/survival/pod, /obj/machinery/door/airlock/survival_pod, /obj/structure/window/shuttle/survival_pod
+#define SMOOTH_GROUP_SURVIVAL_TIANIUM_POD S_OBJ(14) ///turf/closed/wall/mineral/titanium/survival/pod, /obj/machinery/door/airlock/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod
 #define SMOOTH_GROUP_HIERO_WALL S_OBJ(15) ///obj/effect/temp_visual/elite_tumor_wall, /obj/effect/temp_visual/hierophant/wall
 
 #define SMOOTH_GROUP_PAPERFRAME S_OBJ(20) ///obj/structure/window/paperframe, /obj/structure/mineral_door/paperframe
@@ -101,7 +101,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 #define SMOOTH_GROUP_WINDOW_FULLTILE S_OBJ(21) ///turf/closed/indestructible/fakeglass, /obj/structure/window/fulltile, /obj/structure/window/reinforced/fulltile, /obj/structure/window/reinforced/tinted/fulltile, /obj/structure/window/plasma/fulltile, /obj/structure/window/plasma/reinforced/fulltile
 #define SMOOTH_GROUP_WINDOW_FULLTILE_BRONZE S_OBJ(22)	///obj/structure/window/bronze/fulltile
 #define SMOOTH_GROUP_WINDOW_FULLTILE_PLASTITANIUM S_OBJ(23)	///turf/closed/indestructible/opsglass, /obj/structure/window/plasma/reinforced/plastitanium
-#define SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE S_OBJ(24)	///obj/structure/window/shuttle
+#define SMOOTH_GROUP_WINDOW_FULLTILE_SHUTTLE S_OBJ(24)	///obj/structure/window/reinforced/shuttle
 
 #define SMOOTH_GROUP_LATTICE S_OBJ(30) ///obj/structure/lattice
 #define SMOOTH_GROUP_CATWALK S_OBJ(31) ///obj/structure/lattice/catwalk
@@ -125,7 +125,7 @@ DEFINE_BITFIELD(smoothing_flags, list(
 
 #define SMOOTH_GROUP_HEDGE_FLUFF S_OBJ(65) ///obj/structure/fluff/hedge
 
-#define SMOOTH_GROUP_SHUTTLE_PARTS S_OBJ(66) ///obj/structure/window/shuttle, /obj/structure/shuttle/engine/heater
+#define SMOOTH_GROUP_SHUTTLE_PARTS S_OBJ(66) ///obj/structure/window/reinforced/shuttle, /obj/structure/shuttle/engine/heater
 
 #define SMOOTH_GROUP_CLEANABLE_DIRT S_OBJ(67) ///obj/effect/decal/cleanable/dirt
 

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -160,7 +160,7 @@ again.
 /obj/effect/spawner/structure/window/shuttle
 	name = "shuttle window spawner"
 	icon_state = "swindow_spawner"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle)
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle)
 
 
 //plastitanium window
@@ -189,7 +189,7 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod
 	name = "hollow pod window spawner"
 	icon_state = "podwindow_spawner_full"
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/end
 	icon_state = "podwindow_spawner_end"
@@ -197,13 +197,13 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/end/Initialize()
 	switch(dir)
 		if(NORTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 		if(EAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east)
 		if(SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 		if(WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 	. = ..()
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/middle
@@ -212,9 +212,9 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/middle/Initialize()
 	switch(dir)
 		if(NORTH,SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/north)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north)
 		if(EAST,WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/east, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 	. = ..()
 
 /obj/effect/spawner/structure/window/hollow/survival_pod/directional
@@ -223,21 +223,21 @@ again.
 /obj/effect/spawner/structure/window/hollow/survival_pod/directional/Initialize()
 	switch(dir)
 		if(NORTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north)
 		if(NORTHEAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east)
 		if(EAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east)
 		if(SOUTHEAST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/east)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/east)
 		if(SOUTH)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod)
 		if(SOUTHWEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 		if(WEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 		if(NORTHWEST)
-			spawn_list = list(/obj/structure/grille, /obj/structure/window/shuttle/survival_pod/spawner/north, /obj/structure/window/shuttle/survival_pod/spawner/west)
+			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/north, /obj/structure/window/reinforced/shuttle/survival_pod/spawner/west)
 	. = ..()
 
 

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -196,7 +196,7 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	. += GLOB.prglass_recipes
 
 GLOBAL_LIST_INIT(titaniumglass_recipes, list(
-	new/datum/stack_recipe("shuttle window", /obj/structure/window/shuttle/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE)
+	new/datum/stack_recipe("shuttle window", /obj/structure/window/reinforced/shuttle/unanchored, 2, time = 0, on_floor = TRUE, window_checks = TRUE)
 	))
 
 /obj/item/stack/sheet/titaniumglass

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -191,7 +191,7 @@
 				else if(istype(W, /obj/item/stack/sheet/rglass))
 					WD = new/obj/structure/window/reinforced/fulltile(drop_location()) //reinforced window
 				else if(istype(W, /obj/item/stack/sheet/titaniumglass))
-					WD = new/obj/structure/window/shuttle(drop_location())
+					WD = new/obj/structure/window/reinforced/shuttle(drop_location())
 				else if(istype(W, /obj/item/stack/sheet/plastitaniumglass))
 					WD = new/obj/structure/window/plasma/reinforced/plastitanium(drop_location())
 				else

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -664,7 +664,7 @@
 	max_integrity = 300 //WS change - Monstermos
 	glass_amount = 2
 
-/obj/structure/window/shuttle
+/obj/structure/window/reinforced/shuttle
 	name = "shuttle window"
 	desc = "A reinforced, air-locked pod window."
 	icon = 'whitesands/icons/obj/smooth_structures/shuttle_window.dmi'
@@ -685,13 +685,13 @@
 	glass_amount = 2
 	ricochet_chance_mod = 0.9
 
-/obj/structure/window/shuttle/narsie_act()
+/obj/structure/window/reinforced/shuttle/narsie_act()
 	add_atom_colour("#3C3434", FIXED_COLOUR_PRIORITY)
 
-/obj/structure/window/shuttle/tinted
+/obj/structure/window/reinforced/shuttle/tinted
 	opacity = TRUE
 
-/obj/structure/window/shuttle/unanchored
+/obj/structure/window/reinforced/shuttle/unanchored
 	anchored = FALSE
 
 /obj/structure/window/plasma/reinforced/plastitanium

--- a/code/modules/mining/equipment/survival_pod.dm
+++ b/code/modules/mining/equipment/survival_pod.dm
@@ -82,7 +82,7 @@
 //Pod objects
 
 //Window
-/obj/structure/window/shuttle/survival_pod
+/obj/structure/window/reinforced/shuttle/survival_pod
 	name = "pod window"
 	icon = 'icons/obj/smooth_structures/pod_window.dmi'
 	icon_state = "pod_window-0"
@@ -91,13 +91,13 @@
 	smoothing_groups = list(SMOOTH_GROUP_SHUTTLE_PARTS, SMOOTH_GROUP_SURVIVAL_TIANIUM_POD)
 	canSmoothWith = list(SMOOTH_GROUP_SURVIVAL_TIANIUM_POD)
 
-/obj/structure/window/shuttle/survival_pod/spawner/north
+/obj/structure/window/reinforced/shuttle/survival_pod/spawner/north
 	dir = NORTH
 
-/obj/structure/window/shuttle/survival_pod/spawner/east
+/obj/structure/window/reinforced/shuttle/survival_pod/spawner/east
 	dir = EAST
 
-/obj/structure/window/shuttle/survival_pod/spawner/west
+/obj/structure/window/reinforced/shuttle/survival_pod/spawner/west
 	dir = WEST
 
 /obj/structure/window/reinforced/survival_pod

--- a/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_clowncrash.dmm
+++ b/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_clowncrash.dmm
@@ -112,7 +112,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ruin/unpowered)
 "z" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /obj/structure/grille,
 /turf/open/floor/noslip,
 /area/ruin/unpowered)

--- a/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_surface_solgovcrash.dmm
+++ b/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_surface_solgovcrash.dmm
@@ -128,7 +128,7 @@
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "X" = (
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
 "Y" = (

--- a/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_tradepost.dmm
+++ b/voidcrew/_maps/RandomRuins/WastelandRuins/wasteland_tradepost.dmm
@@ -267,7 +267,7 @@
 /area/overmap_encounter/planetoid/wasteland)
 "IN" = (
 /obj/structure/grille,
-/obj/structure/window/shuttle,
+/obj/structure/window/reinforced/shuttle,
 /turf/open/floor/pod/light,
 /area/ruin/unpowered)
 "IU" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes shuttle windows a subtype of reinforced windows, as they already used some of the properties of reinforced windows without being a subtype, making them unable to be deconstructed. Now they can be deconstructed. 

Using an online diff checker tool, this results in a total diff, via VV, of 5 entire damage reflection being added to shuttle windows. That's the only consequence. This is fine.
