### PR TITLE
NT-C Collins, a Nanotrasen scout ship that isn't a bubble

### DIFF
--- a/_maps/configs/NT-C_collins.json
+++ b/_maps/configs/NT-C_collins.json
@@ -1,0 +1,15 @@
+{
+	"prefix": "NT-C",
+	"map_name": "Collins-class Scout Frigate",
+	"map_short_name": "Collins-class",
+	"map_path": "_maps/shuttles/shiptest/voidcrew/collins.dmm",
+	"map_id": "collins",
+	"roundstart": false,
+	"job_slots": {
+		"Captain": 1,
+		"Station Engineer": 1,
+		"Medical Doctor": 1,
+		"Security Officer": 2
+	},
+	"cost": 500
+}

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -54,7 +54,7 @@
 /area/ship/bridge)
 "ah" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/engineering/engine)
 "ai" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -66,7 +66,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/engine)
+/area/ship/bridge)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -147,7 +147,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/bridge)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -188,6 +188,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/machinery/mineral/ore_redemption{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
@@ -373,7 +376,7 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/area/ship/cargo)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
@@ -438,6 +441,7 @@
 /obj/item/tank/internals/oxygen,
 /obj/item/tank/internals/oxygen,
 /obj/item/tank/internals/oxygen,
+/obj/item/pipe_dispenser,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "bf" = (
@@ -617,6 +621,26 @@
 	pixel_y = -24;
 	name = "Cargo Door Controls"
 	},
+/obj/structure/closet/crate,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/rationpack,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/snacks/canned/beans,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
+/obj/item/reagent_containers/food/drinks/waterbottle/large,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "bH" = (
@@ -716,17 +740,6 @@
 /obj/machinery/suit_storage_unit/ert/engineer,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"bY" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "bZ" = (
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "piratestarboardexternal"
@@ -774,6 +787,9 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
+"dL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
 "dU" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -789,9 +805,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
-"ed" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
 "ek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/revolver{
@@ -803,11 +816,8 @@
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
 "ep" = (
-/obj/machinery/power/smes/shuttle/precharged{
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/structure/window/plasma/reinforced/spawner,
 /obj/machinery/door/window/eastright{
@@ -815,14 +825,14 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/engineering/engine)
 "er" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/engineering/engine)
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -863,7 +873,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/medical)
+/area/ship/cargo)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -874,7 +884,7 @@
 /area/ship/medical)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
+/area/ship/medical)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -892,17 +902,12 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"km" = (
-/obj/machinery/atmospherics/components/unary/tank/air,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"mc" = (
+"jo" = (
 /obj/machinery/power/smes/shuttle/precharged{
 	dir = 1
 	},
@@ -915,7 +920,20 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/engineering/engine)
+"km" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"lC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "mD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
@@ -936,6 +954,15 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/engineering/engine)
+"no" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
 "np" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -947,53 +974,6 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"nX" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ship/cargo)
-"oX" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"pS" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"sl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
-"to" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
 "vB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
@@ -1007,31 +987,19 @@
 "wf" = (
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"wK" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
 "wP" = (
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "wR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
-"xW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/medical)
+/area/ship/cargo)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1066,69 +1034,77 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"CF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"GY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Hh" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/medical)
-"Hj" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"Hl" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"Hm" = (
+"FH" = (
 /obj/structure/fans/tiny,
 /obj/machinery/door/poddoor{
 	id = "collins_cargo"
 	},
 /turf/open/floor/plating,
 /area/ship/cargo)
-"IA" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/frame/computer{
-	anchored = 1
-	},
+"Gk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"GX" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"Jr" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/medical)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/pod/light,
+/area/ship/security/armory)
+"KQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"LA" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"Nk" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
+"NL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
 /area/ship/security/armory)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -1161,9 +1137,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"OZ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
+"PX" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Rt" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/medical)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1177,12 +1171,42 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
+"Sb" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"TG" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Ur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
 /obj/machinery/suit_storage_unit/ert/medical,
 /turf/open/floor/plasteel/white,
+/area/ship/medical)
+"UD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
 /area/ship/medical)
 "WJ" = (
 /obj/machinery/light/small{
@@ -1197,34 +1221,37 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"Yb" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
+/obj/structure/closet/crate,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"YD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 
 (1,1,1) = {"
 af
 af
 af
-fW
-ah
-ah
-ah
-Hm
-Hm
-Hm
-ah
-fW
+wR
+aQ
+aQ
+aQ
+FH
+FH
+FH
+aQ
+wR
 af
 af
 af
@@ -1232,37 +1259,37 @@ af
 "}
 (2,1,1) = {"
 af
-nX
+LA
 eu
 ex
-IA
+eA
 aa
 ap
 aw
 wP
 bF
-ah
-ah
-ah
-fW
+aQ
+aQ
+aQ
+wR
 af
 af
 "}
 (3,1,1) = {"
-ah
-ah
-ah
-ah
-ah
-ah
-ah
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 ax
 aq
 Yj
-ah
+aQ
 RY
 aM
-ep
+Sb
 aH
 af
 "}
@@ -1273,14 +1300,14 @@ af
 af
 af
 af
-at
+PX
 ay
 Oe
 OL
 zw
 dy
 br
-ep
+Sb
 aH
 af
 "}
@@ -1291,15 +1318,15 @@ af
 af
 af
 af
-ah
+aQ
 az
 bx
 bH
-aj
-aj
-aj
-aj
-aj
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (6,1,1) = {"
@@ -1308,12 +1335,12 @@ af
 af
 as
 aP
-Hj
-Hj
-OZ
-wR
-OZ
 aj
+aj
+dL
+KQ
+dL
+ah
 Gk
 aD
 aF
@@ -1327,25 +1354,25 @@ as
 aE
 aC
 aW
-Hj
-bg
-sl
-JT
 aj
+bg
+gY
+JT
+ah
 km
 aN
-aj
-aj
-aj
+ah
+ah
+ah
 "}
 (8,1,1) = {"
 af
 af
-Hl
+at
 ab
 ae
 bf
-Hj
+aj
 bl
 fY
 ai
@@ -1353,13 +1380,13 @@ aU
 be
 aD
 aG
-pS
-oX
+jo
+er
 "}
 (9,1,1) = {"
 af
 af
-Hl
+at
 ac
 ag
 am
@@ -1371,26 +1398,26 @@ mU
 aL
 bP
 bX
-bY
+ep
 aK
 "}
 (10,1,1) = {"
 af
 af
-Hl
+at
 ad
 ae
 an
-Hj
-WJ
-gY
-bI
 aj
+WJ
+NL
+bI
+ah
 bO
 bQ
 bk
-pS
-oX
+jo
+er
 "}
 (11,1,1) = {"
 af
@@ -1399,16 +1426,16 @@ aA
 aE
 al
 aB
-Hj
+aj
 ek
 bA
 vB
-aj
+ah
 np
 aO
-aj
-aj
-aj
+ah
+ah
+ah
 "}
 (12,1,1) = {"
 af
@@ -1416,13 +1443,13 @@ af
 af
 aA
 aT
-Hj
-Hj
-OZ
-yi
-OZ
 aj
-GY
+aj
+dL
+yi
+dL
+ah
+lC
 aS
 bZ
 bo
@@ -1435,15 +1462,15 @@ af
 af
 af
 af
-aQ
+Jr
 mD
 bB
 Ur
-aj
-aj
-aj
-aj
-aj
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (14,1,1) = {"
@@ -1453,33 +1480,33 @@ af
 af
 af
 af
-Hh
+UD
 eE
 bC
 bJ
 bM
 dU
 aV
-mc
-er
+Nk
+wK
 af
 "}
 (15,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+Jr
+Jr
+Jr
+Jr
+Jr
+Jr
+Jr
 bu
-CF
+YD
 wf
-ed
+GX
 OD
-to
-mc
-er
+no
+Nk
+wK
 af
 "}
 (16,1,1) = {"
@@ -1487,15 +1514,15 @@ af
 et
 ew
 ez
-eA
+Rt
 ao
 av
 bv
-Yb
+TG
 bK
-ed
-ed
-ed
+GX
+GX
+GX
 df
 af
 af
@@ -1504,14 +1531,14 @@ af
 af
 af
 af
-xW
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-ed
+fW
+Jr
+Jr
+Jr
+Jr
+Jr
+Jr
+GX
 df
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -1,0 +1,1502 @@
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
+"aa" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 4;
+	pixel_x = -24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"ab" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"ac" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/helm,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"ad" = (
+/obj/structure/table,
+/obj/machinery/button/door{
+	id = "piratebridge";
+	name = "Bridge Shutters Control";
+	pixel_y = -5
+	},
+/obj/item/radio/intercom{
+	pixel_y = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/item/areaeditor/shuttle,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"ae" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"af" = (
+/turf/template_noop,
+/area/template_noop)
+"ag" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"ah" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
+"ai" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small,
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"aj" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/medical)
+"al" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/communications{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"am" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"an" = (
+/obj/machinery/button/door{
+	id = "piratebridgebolt";
+	name = "Bridge Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"ao" = (
+/obj/structure/chair/comfy/shuttle{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/medical)
+"ap" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Port Gun Battery"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"aq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"as" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"at" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"au" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/machinery/door/airlock/command{
+	id_tag = "piratebridgebolt";
+	name = "Bridge"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"av" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Starboard Gun Battery"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"aw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"ax" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"ay" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"az" = (
+/obj/machinery/selling_pad,
+/obj/effect/turf_decal/box,
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"aA" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"aB" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/computer/monitor/secret{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"aC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/displaycase/captain,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"aD" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/engine)
+"aE" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"aF" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "pirateportexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aG" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/machinery/power/terminal,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aH" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"aI" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aJ" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "pirateportexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aK" = (
+/obj/machinery/power/shuttle/engine/fueled/plasma{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aL" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aM" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/machinery/computer/cargo/express{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"aN" = (
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "pirateportexternal";
+	name = "External Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = -4;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aO" = (
+/obj/machinery/light/small,
+/obj/machinery/button/door{
+	id = "piratestarboardexternal";
+	name = "External Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 4;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aP" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"aQ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo)
+"aR" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/engineering/engine)
+"aS" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"aT" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"aU" = (
+/obj/structure/sign/departments/engineering,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/engine)
+"aV" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"aW" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
+	},
+/obj/structure/closet/secure_closet/captains,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"be" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/rack,
+/obj/item/storage/toolbox/mechanical{
+	pixel_y = 4
+	},
+/obj/item/flashlight{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/lights/bulbs,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 10
+	},
+/obj/item/multitool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
+"bg" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 3
+	},
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "1";
+	name = "Gun Rack Access"
+	},
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"bk" = (
+/obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/power/terminal,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bl" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table,
+/obj/item/gun/energy/laser{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/item/gun/energy/laser{
+	pixel_y = 3
+	},
+/obj/machinery/door/window/brigdoor{
+	req_access_txt = "1";
+	name = "Gun Rack Access"
+	},
+/obj/structure/window/reinforced/spawner/east,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"bm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"bo" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"br" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/obj/machinery/modular_computer/console/preset/command{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"bu" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/secure_closet{
+	icon_state = "med";
+	name = "medicine locker"
+	},
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/brute,
+/obj/item/storage/firstaid/fire,
+/obj/item/storage/firstaid/toxin,
+/obj/item/storage/firstaid/o2,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"by" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"bA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"bB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bC" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bF" = (
+/obj/machinery/button/door{
+	id = "collins_cargo";
+	pixel_y = -24;
+	name = "Cargo Door Controls"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"bH" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/selling_pad_control{
+	dir = 8
+	},
+/obj/machinery/airalarm/all_access{
+	dir = 1;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"bI" = (
+/obj/machinery/light/small,
+/obj/machinery/recharger,
+/obj/structure/table,
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"bJ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bK" = (
+/obj/machinery/sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"bM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock{
+	name = "Cryogenics"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"bO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1;
+	sheets = 35
+	},
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bQ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bX" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"bZ" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "piratestarboardexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"ce" = (
+/obj/machinery/door/airlock/external/glass{
+	id_tag = "piratestarboardexternal"
+	},
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/fans/tiny,
+/obj/docking_port/mobile{
+	dwidth = 11;
+	width = 17;
+	height = 16
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"df" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"dy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"dU" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"ek" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/revolver{
+	pixel_x = 32
+	},
+/obj/machinery/vending/security/marine/solgov{
+	all_items_free = 1
+	},
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"ep" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"er" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
+"et" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/medical)
+"eu" = (
+/obj/structure/girder,
+/obj/item/stack/rods{
+	amount = 3
+	},
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"ew" = (
+/obj/structure/girder,
+/obj/item/stack/rods{
+	amount = 5
+	},
+/turf/open/floor/plating/airless,
+/area/ship/medical)
+"ex" = (
+/obj/structure/window/reinforced,
+/obj/structure/frame/machine,
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"ez" = (
+/obj/structure/window/reinforced,
+/obj/structure/frame/machine,
+/obj/item/stack/cable_coil/cut/red,
+/turf/open/floor/plating/airless,
+/area/ship/medical)
+"eA" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/cargo)
+"eE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/table/optable,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"fW" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
+"fY" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"gY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"hB" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"ij" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/medical)
+"jl" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"km" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"mD" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"mU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/engineering{
+	name = "Engineering"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/engineering/engine)
+"np" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/smes/engineering,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"qN" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"vB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger,
+/obj/structure/table,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"wf" = (
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wP" = (
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"wR" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
+"ye" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"yi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Bay"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/security/armory)
+"zd" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"zw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office"
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"BU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Dh" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"Dl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"Eh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"HB" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/medical)
+"JT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/closet/crate,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"Kx" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Oe" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"OD" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/machinery/cryopod,
+/obj/machinery/computer/cryopod{
+	pixel_x = 32
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"OL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"QL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"RY" = (
+/obj/machinery/airalarm/all_access{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"Ur" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"UA" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"WJ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/security/marine/solgov{
+	all_items_free = 1
+	},
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"Yj" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/south,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"YO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"Zr" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
+"Zz" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/medical)
+
+(1,1,1) = {"
+af
+af
+af
+wR
+aQ
+aQ
+aQ
+jl
+jl
+jl
+aQ
+wR
+af
+af
+af
+af
+"}
+(2,1,1) = {"
+af
+qN
+eu
+ex
+eA
+aa
+ap
+aw
+wP
+bF
+aQ
+aQ
+aQ
+wR
+af
+af
+"}
+(3,1,1) = {"
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+ax
+aq
+Yj
+aQ
+RY
+aM
+ep
+aH
+af
+"}
+(4,1,1) = {"
+af
+af
+af
+af
+af
+af
+Eh
+ay
+Oe
+OL
+zw
+dy
+br
+ep
+aH
+af
+"}
+(5,1,1) = {"
+af
+af
+af
+af
+af
+af
+aQ
+az
+bx
+bH
+aD
+aD
+aD
+aD
+aD
+aR
+"}
+(6,1,1) = {"
+af
+af
+af
+as
+aP
+df
+df
+ah
+Dl
+ah
+aD
+ye
+aS
+aF
+aI
+aJ
+"}
+(7,1,1) = {"
+af
+af
+as
+aE
+aC
+aW
+df
+bg
+gY
+JT
+aD
+km
+aN
+aD
+aD
+aD
+"}
+(8,1,1) = {"
+af
+af
+at
+ab
+ae
+bf
+df
+bl
+fY
+ai
+aU
+be
+aS
+aG
+UA
+Kx
+"}
+(9,1,1) = {"
+af
+af
+at
+ac
+ag
+am
+au
+bm
+by
+bm
+mU
+aL
+bP
+bX
+hB
+aK
+"}
+(10,1,1) = {"
+af
+af
+at
+ad
+ae
+an
+df
+WJ
+YO
+bI
+aD
+bO
+bQ
+bk
+UA
+Kx
+"}
+(11,1,1) = {"
+af
+af
+aA
+aE
+al
+aB
+df
+ek
+bA
+vB
+aD
+np
+aO
+aD
+aD
+aD
+"}
+(12,1,1) = {"
+af
+af
+af
+aA
+aT
+df
+df
+ah
+yi
+ah
+aD
+Gk
+QL
+bZ
+bo
+ce
+"}
+(13,1,1) = {"
+af
+af
+af
+af
+af
+af
+aj
+mD
+bB
+Ur
+aD
+aD
+aD
+aD
+aD
+aR
+"}
+(14,1,1) = {"
+af
+af
+af
+af
+af
+af
+ij
+eE
+bC
+bJ
+bM
+dU
+aV
+Zr
+er
+af
+"}
+(15,1,1) = {"
+aj
+aj
+aj
+aj
+aj
+aj
+aj
+bu
+BU
+wf
+Dh
+OD
+zd
+Zr
+er
+af
+"}
+(16,1,1) = {"
+af
+et
+ew
+ez
+Zz
+ao
+av
+bv
+wf
+bK
+Dh
+Dh
+Dh
+fW
+af
+af
+"}
+(17,1,1) = {"
+af
+af
+af
+HB
+aj
+aj
+aj
+aj
+aj
+aj
+Dh
+fW
+af
+af
+af
+af
+"}

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -54,7 +54,7 @@
 /area/ship/bridge)
 "ah" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
+/area/ship/engineering/engine)
 "ai" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -65,7 +65,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/area/ship/cargo)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -146,7 +146,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/bridge)
+/area/ship/cargo)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -235,7 +235,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "aD" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
 /area/ship/engineering/engine)
 "aE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -366,12 +367,15 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/medical)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
 "aS" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "aT" = (
@@ -734,8 +738,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "df" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
 "dy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -790,14 +794,14 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/crew/cryo)
 "er" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/engineering/engine)
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -838,7 +842,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/cargo)
+/area/ship/medical)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -847,9 +851,23 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"fO" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
+/area/ship/cargo)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -872,33 +890,16 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"hB" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
+"ki" = (
+/obj/structure/window/reinforced{
 	dir = 1;
-	name = "Engine Access"
+	pixel_y = 1
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"ij" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
+/obj/structure/frame/computer{
+	anchored = 1
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/medical)
-"jl" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
-/turf/open/floor/plating,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/ship/cargo)
 "km" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
@@ -939,31 +940,7 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"qN" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ship/cargo)
-"vB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharger,
-/obj/structure/table,
-/turf/open/floor/pod/light,
-/area/ship/security/armory)
-"wf" = (
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"wP" = (
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"wR" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
-"ye" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"yi" = (
+"oP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -982,40 +959,59 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
-"zd" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
+"pe" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
 	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
-"zw" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor/border_only{
 	dir = 1
 	},
-/obj/machinery/door/firedoor/border_only,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Office"
-	},
-/turf/open/floor/wood,
-/area/ship/cargo)
-"BU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
 /area/ship/medical)
-"Dh" = (
+"tB" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/cryo)
-"Dl" = (
+"uY" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"vB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger,
+/obj/structure/table,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"wf" = (
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wP" = (
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"wR" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/medical)
+"wX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
+"yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1034,7 +1030,59 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
+"yQ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
+"zc" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"zw" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/machinery/door/firedoor/border_only,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Office"
+	},
+/turf/open/floor/wood,
+/area/ship/cargo)
+"Cj" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Eh" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"IF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"JH" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
 	},
@@ -1043,15 +1091,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/cargo)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"HB" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/medical)
+/area/ship/bridge)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -1059,13 +1099,9 @@
 /obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"Kx" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
+"Ke" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -1097,13 +1133,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"QL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+"OZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1123,20 +1158,6 @@
 /obj/structure/cable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"UA" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "WJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -1150,6 +1171,13 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
+"XL" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
@@ -1158,55 +1186,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"YO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"YR" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"ZD" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
-"Zr" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
-"Zz" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/frame/computer{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/ship/medical)
 
 (1,1,1) = {"
 af
 af
 af
-wR
-aQ
-aQ
-aQ
-jl
-jl
-jl
-aQ
-wR
+fW
+aj
+aj
+aj
+Eh
+Eh
+Eh
+aj
+fW
 af
 af
 af
@@ -1214,37 +1220,37 @@ af
 "}
 (2,1,1) = {"
 af
-qN
+YR
 eu
 ex
-eA
+ki
 aa
 ap
 aw
 wP
 bF
-aQ
-aQ
-aQ
-wR
+aj
+aj
+aj
+fW
 af
 af
 "}
 (3,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 ax
 aq
 Yj
-aQ
+aj
 RY
 aM
-ep
+uY
 aH
 af
 "}
@@ -1255,14 +1261,14 @@ af
 af
 af
 af
-Eh
+at
 ay
 Oe
 OL
 zw
 dy
 br
-ep
+uY
 aH
 af
 "}
@@ -1273,15 +1279,15 @@ af
 af
 af
 af
-aQ
+aj
 az
 bx
 bH
-aD
-aD
-aD
-aD
-aD
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (6,1,1) = {"
@@ -1290,14 +1296,14 @@ af
 af
 as
 aP
-df
-df
+Ke
+Ke
+yQ
+yi
+yQ
 ah
-Dl
-ah
+Gk
 aD
-ye
-aS
 aF
 aI
 aJ
@@ -1309,39 +1315,39 @@ as
 aE
 aC
 aW
-df
+Ke
 bg
 gY
 JT
-aD
+ah
 km
 aN
-aD
-aD
-aD
+ah
+ah
+ah
 "}
 (8,1,1) = {"
 af
 af
-at
+JH
 ab
 ae
 bf
-df
+Ke
 bl
 fY
 ai
 aU
 be
-aS
+aD
 aG
-UA
-Kx
+fO
+er
 "}
 (9,1,1) = {"
 af
 af
-at
+JH
 ac
 ag
 am
@@ -1353,26 +1359,26 @@ mU
 aL
 bP
 bX
-hB
+zc
 aK
 "}
 (10,1,1) = {"
 af
 af
-at
+JH
 ad
 ae
 an
-df
+Ke
 WJ
-YO
+wX
 bI
-aD
+ah
 bO
 bQ
 bk
-UA
-Kx
+fO
+er
 "}
 (11,1,1) = {"
 af
@@ -1381,16 +1387,16 @@ aA
 aE
 al
 aB
-df
+Ke
 ek
 bA
 vB
-aD
+ah
 np
 aO
-aD
-aD
-aD
+ah
+ah
+ah
 "}
 (12,1,1) = {"
 af
@@ -1398,14 +1404,14 @@ af
 af
 aA
 aT
-df
-df
+Ke
+Ke
+yQ
+oP
+yQ
 ah
-yi
-ah
-aD
-Gk
-QL
+IF
+aS
 bZ
 bo
 ce
@@ -1417,15 +1423,15 @@ af
 af
 af
 af
-aj
+aQ
 mD
 bB
 Ur
-aD
-aD
-aD
-aD
-aD
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (14,1,1) = {"
@@ -1435,33 +1441,33 @@ af
 af
 af
 af
-ij
+pe
 eE
 bC
 bJ
 bM
 dU
 aV
-Zr
-er
+ep
+XL
 af
 "}
 (15,1,1) = {"
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 bu
-BU
+OZ
 wf
-Dh
+tB
 OD
-zd
-Zr
-er
+ZD
+ep
+XL
 af
 "}
 (16,1,1) = {"
@@ -1469,16 +1475,16 @@ af
 et
 ew
 ez
-Zz
+eA
 ao
 av
 bv
-wf
+Cj
 bK
-Dh
-Dh
-Dh
-fW
+tB
+tB
+tB
+df
 af
 af
 "}
@@ -1486,15 +1492,15 @@ af
 af
 af
 af
-HB
-aj
-aj
-aj
-aj
-aj
-aj
-Dh
-fW
+wR
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+tB
+df
 af
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -41,9 +41,8 @@
 /area/ship/bridge)
 "ae" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "af" = (
 /turf/template_noop,
 /area/template_noop)
@@ -54,9 +53,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ah" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/engineering/engine)
 "ai" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -68,7 +66,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/engine)
+/area/ship/cargo)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -149,7 +147,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/bridge)
+/area/ship/cargo)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -238,12 +236,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "aD" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/engineering/engine)
 "aE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
@@ -373,12 +368,15 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/medical)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
 "aS" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "aT" = (
@@ -813,7 +811,7 @@
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/cargo)
+/area/ship/medical)
 "eu" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
@@ -850,7 +848,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/medical)
+/area/ship/cargo)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -859,20 +857,9 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"fp" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
+/area/ship/medical)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -882,17 +869,35 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"gY" = (
+"gj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/pod/dark,
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Bay"
+	},
+/turf/open/floor/plasteel/white,
 /area/ship/security/armory)
-"jj" = (
+"gI" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"gY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -905,6 +910,13 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
+"iQ" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
 "km" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/machinery/firealarm{
@@ -913,10 +925,20 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"kw" = (
+"ln" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"lJ" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/medical)
+/area/ship/cargo)
 "mD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
@@ -948,36 +970,21 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"ut" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"va" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
+"oI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/pod/dark,
 /area/ship/security/armory)
 "vB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
 /obj/structure/table,
 /turf/open/floor/pod/light,
-/area/ship/security/armory)
-"vZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Bay"
-	},
-/turf/open/floor/plasteel/white,
 /area/ship/security/armory)
 "wf" = (
 /turf/open/floor/plasteel/white,
@@ -986,18 +993,8 @@
 /turf/open/floor/plasteel,
 /area/ship/cargo)
 "wR" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
-"xy" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/medical)
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1017,6 +1014,34 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
+"yU" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"zm" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1032,31 +1057,16 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Ab" = (
+"Be" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"Db" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Ak" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Fm" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Im" = (
+"DU" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
 	},
@@ -1065,21 +1075,25 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/cargo)
-"JD" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
+/area/ship/medical)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"Gu" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"IU" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
@@ -1087,19 +1101,14 @@
 /obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"JY" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/medical)
-"LT" = (
+"Ka" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
+/obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"NY" = (
+"MM" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
+/area/ship/bridge)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -1144,6 +1153,20 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
+"Su" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
+"Tz" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
+/area/ship/medical)
 "Ur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
@@ -1164,40 +1187,6 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"WK" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
-"WP" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
-"WU" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/frame/computer{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/ship/cargo)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
@@ -1206,20 +1195,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"Zw" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 
 (1,1,1) = {"
 af
 af
 af
-fW
-aQ
-aQ
-aQ
-aD
-aD
-aD
-aQ
-fW
+wR
+aj
+aj
+aj
+iQ
+iQ
+iQ
+aj
+wR
 af
 af
 af
@@ -1227,38 +1227,38 @@ af
 "}
 (2,1,1) = {"
 af
-et
+lJ
 eu
 ex
-WU
+eA
 aa
 ap
 aw
 wP
 bF
-aQ
-aQ
-aQ
-fW
+aj
+aj
+aj
+wR
 af
 af
 "}
 (3,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 ax
 aq
 Yj
-aQ
+aj
 RY
 aM
-WP
-Fm
+yU
+Gu
 af
 "}
 (4,1,1) = {"
@@ -1268,15 +1268,15 @@ af
 af
 af
 af
-Im
+at
 ay
 Oe
 OL
 zw
 dy
 br
-WP
-Fm
+yU
+Gu
 af
 "}
 (5,1,1) = {"
@@ -1286,15 +1286,15 @@ af
 af
 af
 af
-aQ
+aj
 az
 bx
 bH
-aj
-aj
-aj
-aj
-aj
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (6,1,1) = {"
@@ -1303,14 +1303,14 @@ af
 af
 as
 aP
-ut
-ut
-va
+MM
+MM
+Su
 yi
-va
-aj
+Su
+ah
 Gk
-aS
+aD
 aF
 aI
 aJ
@@ -1322,39 +1322,39 @@ as
 aE
 aC
 aW
-ut
+MM
 bg
-jj
+gY
 JT
-aj
+ah
 km
 aN
-aj
-aj
-aj
+ah
+ah
+ah
 "}
 (8,1,1) = {"
 af
 af
-at
+ln
 ab
-ah
+ae
 bf
-ut
+MM
 bl
 fY
 ai
 aU
 be
-aS
+aD
 aG
-JD
+zm
 er
 "}
 (9,1,1) = {"
 af
 af
-at
+ln
 ac
 ag
 am
@@ -1366,25 +1366,25 @@ mU
 aL
 bP
 bX
-fp
+Zw
 aK
 "}
 (10,1,1) = {"
 af
 af
-at
+ln
 ad
-ah
+ae
 an
-ut
+MM
 WJ
-gY
+oI
 bI
-aj
+ah
 bO
 bQ
 bk
-JD
+zm
 er
 "}
 (11,1,1) = {"
@@ -1394,16 +1394,16 @@ aA
 aE
 al
 aB
-ut
+MM
 ek
 bA
 vB
-aj
+ah
 np
 aO
-aj
-aj
-aj
+ah
+ah
+ah
 "}
 (12,1,1) = {"
 af
@@ -1411,14 +1411,14 @@ af
 af
 aA
 aT
-ut
-ut
-va
-vZ
-va
-aj
-ae
-LT
+MM
+MM
+Su
+gj
+Su
+ah
+Ka
+aS
 bZ
 bo
 ce
@@ -1430,15 +1430,15 @@ af
 af
 af
 af
-wR
+aQ
 mD
 bB
 Ur
-aj
-aj
-aj
-aj
-aj
+ah
+ah
+ah
+ah
+ah
 aR
 "}
 (14,1,1) = {"
@@ -1448,7 +1448,7 @@ af
 af
 af
 af
-xy
+DU
 eE
 bC
 bJ
@@ -1460,37 +1460,37 @@ aH
 af
 "}
 (15,1,1) = {"
-wR
-wR
-wR
-wR
-wR
-wR
-wR
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 bu
-Ak
+IU
 wf
-NY
+Be
 OD
-WK
+gI
 ep
 aH
 af
 "}
 (16,1,1) = {"
 af
-kw
+et
 ew
 ez
-eA
+Tz
 ao
 av
 bv
-Ab
+Db
 bK
-NY
-NY
-NY
+Be
+Be
+Be
 df
 af
 af
@@ -1499,14 +1499,14 @@ af
 af
 af
 af
-JY
-wR
-wR
-wR
-wR
-wR
-wR
-NY
+fW
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+Be
 df
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -40,8 +40,10 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ae" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "af" = (
 /turf/template_noop,
 /area/template_noop)
@@ -61,6 +63,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small,
+/obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
 "aj" = (
@@ -146,7 +149,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/bridge)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -235,8 +238,12 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "aD" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
 "aE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
@@ -271,7 +278,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/engineering/engine)
+/area/ship/crew/cryo)
 "aI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -366,7 +373,7 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/area/ship/cargo)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
@@ -389,10 +396,7 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engine)
 "aV" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
+/obj/machinery/power/apc/auto_name/west,
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
@@ -427,6 +431,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "bf" = (
@@ -510,25 +518,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"bs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
 "bu" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -720,6 +709,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/machinery/suit_storage_unit/ert/engineer,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "bZ" = (
@@ -756,12 +746,8 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "df" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/cryo)
 "dy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -816,18 +802,18 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/crew/cryo)
 "er" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/engineering/engine)
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/medical)
+/area/ship/cargo)
 "eu" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
@@ -864,7 +850,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/cargo)
+/area/ship/medical)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -873,9 +859,20 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"fp" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
+/area/ship/cargo)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -895,20 +892,19 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"hh" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/frame/computer{
-	anchored = 1
+"jj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/pod/dark,
-/area/ship/medical)
-"iL" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/security/armory)
 "km" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/machinery/firealarm{
@@ -917,20 +913,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"ko" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
+"kw" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/medical)
 "mD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
@@ -962,63 +948,19 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"rH" = (
+"ut" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"rI" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/medical)
-"sW" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/cargo)
-"un" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"uv" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/bridge)
+"va" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
 "vB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
 /obj/structure/table,
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"wf" = (
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"wP" = (
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"wR" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
-"yi" = (
+"vZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1037,6 +979,44 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
+"wf" = (
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wP" = (
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"wR" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/medical)
+"xy" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/medical)
+"yi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1052,15 +1032,46 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Bb" = (
+"Ab" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Ak" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Bx" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
+"Fm" = (
+/obj/machinery/power/shuttle/engine/electric{
 	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Im" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"JD" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /obj/structure/window/plasma/reinforced/spawner,
 /obj/machinery/door/window/eastright{
@@ -1069,38 +1080,26 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"Er" = (
-/obj/machinery/power/apc/auto_name/west,
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
-"EB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"FH" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Gl" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/medical)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/crate,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
+"JY" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/medical)
+"LT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"NY" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -1132,16 +1131,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"QM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1159,6 +1148,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
 /obj/structure/cable,
+/obj/machinery/suit_storage_unit/ert/medical,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "WJ" = (
@@ -1174,9 +1164,39 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"WO" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+"WK" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"WP" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
+"WU" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod/dark,
 /area/ship/cargo)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1186,33 +1206,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"Zu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
 
 (1,1,1) = {"
 af
 af
 af
-wR
-iL
-iL
-iL
-df
-df
-df
-iL
-wR
+fW
+aQ
+aQ
+aQ
+aD
+aD
+aD
+aQ
+fW
 af
 af
 af
@@ -1220,38 +1227,38 @@ af
 "}
 (2,1,1) = {"
 af
-WO
+et
 eu
 ex
-eA
+WU
 aa
 ap
 aw
 wP
 bF
-iL
-iL
-iL
-wR
+aQ
+aQ
+aQ
+fW
 af
 af
 "}
 (3,1,1) = {"
-iL
-iL
-iL
-iL
-iL
-iL
-iL
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 ax
 aq
 Yj
-iL
+aQ
 RY
 aM
-ep
-sW
+WP
+Fm
 af
 "}
 (4,1,1) = {"
@@ -1261,15 +1268,15 @@ af
 af
 af
 af
-at
+Im
 ay
 Oe
 OL
 zw
 dy
 br
-ep
-sW
+WP
+Fm
 af
 "}
 (5,1,1) = {"
@@ -1279,7 +1286,7 @@ af
 af
 af
 af
-iL
+aQ
 az
 bx
 bH
@@ -1296,11 +1303,11 @@ af
 af
 as
 aP
-aD
-aD
-ae
-bs
-ae
+ut
+ut
+va
+yi
+va
 aj
 Gk
 aS
@@ -1315,9 +1322,9 @@ as
 aE
 aC
 aW
-aD
+ut
 bg
-Zu
+jj
 JT
 aj
 km
@@ -1329,11 +1336,11 @@ aj
 (8,1,1) = {"
 af
 af
-QM
+at
 ab
 ah
 bf
-aD
+ut
 bl
 fY
 ai
@@ -1341,13 +1348,13 @@ aU
 be
 aS
 aG
-ko
-aH
+JD
+er
 "}
 (9,1,1) = {"
 af
 af
-QM
+at
 ac
 ag
 am
@@ -1359,17 +1366,17 @@ mU
 aL
 bP
 bX
-Bx
+fp
 aK
 "}
 (10,1,1) = {"
 af
 af
-QM
+at
 ad
 ah
 an
-aD
+ut
 WJ
 gY
 bI
@@ -1377,8 +1384,8 @@ aj
 bO
 bQ
 bk
-ko
-aH
+JD
+er
 "}
 (11,1,1) = {"
 af
@@ -1387,7 +1394,7 @@ aA
 aE
 al
 aB
-aD
+ut
 ek
 bA
 vB
@@ -1404,14 +1411,14 @@ af
 af
 aA
 aT
-aD
-aD
-ae
-yi
-ae
+ut
+ut
+va
+vZ
+va
 aj
-EB
-un
+ae
+LT
 bZ
 bo
 ce
@@ -1423,7 +1430,7 @@ af
 af
 af
 af
-aQ
+wR
 mD
 bB
 Ur
@@ -1441,50 +1448,50 @@ af
 af
 af
 af
-rI
+xy
 eE
 bC
 bJ
 bM
 dU
-Er
-uv
-er
+aV
+ep
+aH
 af
 "}
 (15,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+wR
+wR
+wR
+wR
+wR
+wR
+wR
 bu
-Bb
+Ak
 wf
-rH
+NY
 OD
-aV
-uv
-er
+WK
+ep
+aH
 af
 "}
 (16,1,1) = {"
 af
-et
+kw
 ew
 ez
-hh
+eA
 ao
 av
 bv
-FH
+Ab
 bK
-rH
-rH
-rH
-fW
+NY
+NY
+NY
+df
 af
 af
 "}
@@ -1492,15 +1499,15 @@ af
 af
 af
 af
-Gl
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-rH
-fW
+JY
+wR
+wR
+wR
+wR
+wR
+wR
+NY
+df
 af
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -66,7 +66,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/medical)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -147,7 +147,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/medical)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -273,7 +273,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/cargo)
 "aI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -302,6 +302,11 @@
 "aK" = (
 /obj/machinery/power/shuttle/engine/fueled/plasma{
 	dir = 1
+	},
+/obj/docking_port/mobile{
+	dwidth = 11;
+	width = 17;
+	height = 16
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
@@ -368,7 +373,7 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/area/ship/cargo)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
@@ -736,11 +741,6 @@
 	},
 /obj/machinery/door/firedoor/border_only,
 /obj/structure/fans/tiny,
-/obj/docking_port/mobile{
-	dwidth = 11;
-	width = 17;
-	height = 16
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "df" = (
@@ -811,7 +811,7 @@
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/medical)
+/area/ship/cargo)
 "eu" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
@@ -857,9 +857,19 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
+"fP" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/medical)
+/area/ship/cargo)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -869,34 +879,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"gj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/medical/glass{
-	name = "Medical Bay"
-	},
-/turf/open/floor/plasteel/white,
-/area/ship/security/armory)
-"gI" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
-	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
 "gY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -910,13 +892,6 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"iQ" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
 "km" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /obj/machinery/firealarm{
@@ -925,23 +900,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"ln" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
-"lJ" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ship/cargo)
 "mD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"mO" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "mU" = (
@@ -970,16 +937,23 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"oI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"ny" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"tS" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/pod/dark,
-/area/ship/security/armory)
+/area/ship/medical)
 "vB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
@@ -989,13 +963,7 @@
 "wf" = (
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"wP" = (
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"wR" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
-"yi" = (
+"wH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -1014,26 +982,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"yU" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
+"wP" = (
+/turf/open/floor/plasteel,
 /area/ship/cargo)
-"zm" = (
-/obj/machinery/power/smes/shuttle/precharged{
+"wR" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
 	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
 	},
 /obj/structure/window/plasma/reinforced/spawner,
 /obj/machinery/door/window/eastright{
@@ -1042,6 +996,32 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"ya" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/medical)
+"yi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/medical/glass{
+	name = "Medical Bay"
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/security/armory)
+"yB" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/medical)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1057,16 +1037,71 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Be" = (
+"Cb" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"CG" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"Gk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/autolathe,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Jl" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"JT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"JX" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/crew/cryo)
-"Db" = (
-/obj/machinery/light{
-	dir = 4
+"KC" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"DU" = (
+/turf/open/floor/plating,
+/area/ship/cargo)
+"NP" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
+"Oe" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"Of" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
 	},
@@ -1075,47 +1110,17 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/medical)
-"Gk" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/autolathe,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"Gu" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
 /area/ship/cargo)
-"IU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"Ow" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"JT" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/obj/machinery/suit_storage_unit/ert/security,
-/turf/open/floor/pod/light,
-/area/ship/security/armory)
-"Ka" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"MM" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
-"Oe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
 "OD" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1140,6 +1145,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
+"Qk" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1153,20 +1172,12 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Su" = (
+"TS" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/security/armory)
-"Tz" = (
-/obj/structure/window/reinforced{
-	dir = 1;
-	pixel_y = 1
-	},
-/obj/structure/frame/computer{
-	anchored = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/pod/dark,
-/area/ship/medical)
+"TX" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "Ur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
@@ -1195,31 +1206,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"Zw" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 
 (1,1,1) = {"
 af
 af
 af
-wR
-aj
-aj
-aj
-iQ
-iQ
-iQ
-aj
-wR
+fW
+aQ
+aQ
+aQ
+KC
+KC
+KC
+aQ
+fW
 af
 af
 af
@@ -1227,7 +1227,7 @@ af
 "}
 (2,1,1) = {"
 af
-lJ
+et
 eu
 ex
 eA
@@ -1236,29 +1236,29 @@ ap
 aw
 wP
 bF
-aj
-aj
-aj
-wR
+aQ
+aQ
+aQ
+fW
 af
 af
 "}
 (3,1,1) = {"
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 ax
 aq
 Yj
-aj
+aQ
 RY
 aM
-yU
-Gu
+Qk
+aH
 af
 "}
 (4,1,1) = {"
@@ -1268,15 +1268,15 @@ af
 af
 af
 af
-at
+Of
 ay
 Oe
 OL
 zw
 dy
 br
-yU
-Gu
+Qk
+aH
 af
 "}
 (5,1,1) = {"
@@ -1286,7 +1286,7 @@ af
 af
 af
 af
-aj
+aQ
 az
 bx
 bH
@@ -1303,11 +1303,11 @@ af
 af
 as
 aP
-MM
-MM
-Su
-yi
-Su
+TX
+TX
+TS
+wH
+TS
 ah
 Gk
 aD
@@ -1322,7 +1322,7 @@ as
 aE
 aC
 aW
-MM
+TX
 bg
 gY
 JT
@@ -1336,11 +1336,11 @@ ah
 (8,1,1) = {"
 af
 af
-ln
+fP
 ab
 ae
 bf
-MM
+TX
 bl
 fY
 ai
@@ -1348,13 +1348,13 @@ aU
 be
 aD
 aG
-zm
+Jl
 er
 "}
 (9,1,1) = {"
 af
 af
-ln
+fP
 ac
 ag
 am
@@ -1366,25 +1366,25 @@ mU
 aL
 bP
 bX
-Zw
+wR
 aK
 "}
 (10,1,1) = {"
 af
 af
-ln
+fP
 ad
 ae
 an
-MM
+TX
 WJ
-oI
+Ow
 bI
 ah
 bO
 bQ
 bk
-zm
+Jl
 er
 "}
 (11,1,1) = {"
@@ -1394,7 +1394,7 @@ aA
 aE
 al
 aB
-MM
+TX
 ek
 bA
 vB
@@ -1411,13 +1411,13 @@ af
 af
 aA
 aT
-MM
-MM
-Su
-gj
-Su
+TX
+TX
+TS
+yi
+TS
 ah
-Ka
+Cb
 aS
 bZ
 bo
@@ -1430,7 +1430,7 @@ af
 af
 af
 af
-aQ
+aj
 mD
 bB
 Ur
@@ -1448,7 +1448,7 @@ af
 af
 af
 af
-DU
+at
 eE
 bC
 bJ
@@ -1456,41 +1456,41 @@ bM
 dU
 aV
 ep
-aH
+NP
 af
 "}
 (15,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+aj
+aj
+aj
+aj
+aj
+aj
+aj
 bu
-IU
+ny
 wf
-Be
+JX
 OD
-gI
+CG
 ep
-aH
+NP
 af
 "}
 (16,1,1) = {"
 af
-et
+yB
 ew
 ez
-Tz
+tS
 ao
 av
 bv
-Db
+mO
 bK
-Be
-Be
-Be
+JX
+JX
+JX
 df
 af
 af
@@ -1499,14 +1499,14 @@ af
 af
 af
 af
-fW
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-Be
+ya
+aj
+aj
+aj
+aj
+aj
+aj
+JX
 df
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -54,7 +54,7 @@
 /area/ship/bridge)
 "ah" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/engine)
+/area/ship/cargo)
 "ai" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -66,7 +66,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/medical)
+/area/ship/engineering/engine)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -147,7 +147,7 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
-/area/ship/medical)
+/area/ship/cargo)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor/border_only{
@@ -373,7 +373,7 @@
 /area/ship/bridge)
 "aQ" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/medical)
 "aR" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/engineering/engine)
@@ -477,9 +477,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/airalarm/all_access{
-	pixel_y = 24
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
 /obj/item/gun/energy/laser{
@@ -545,6 +542,10 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "bx" = (
@@ -715,6 +716,17 @@
 /obj/machinery/suit_storage_unit/ert/engineer,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"bY" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
 "bZ" = (
 /obj/machinery/door/airlock/external/glass{
 	id_tag = "piratestarboardexternal"
@@ -777,6 +789,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
+"ed" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
 "ek" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sign/poster/contraband/revolver{
@@ -800,18 +815,18 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/cargo)
 "er" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/engineering/engine)
+/area/ship/crew/cryo)
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/ship/cargo)
+/area/ship/medical)
 "eu" = (
 /obj/structure/girder,
 /obj/item/stack/rods{
@@ -848,7 +863,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/cargo)
+/area/ship/medical)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -857,16 +872,6 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"fP" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
@@ -887,9 +892,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
 "km" = (
@@ -900,15 +902,23 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
+"mc" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
 "mD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/operating,
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"mO" = (
-/obj/machinery/light{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
 "mU" = (
@@ -937,33 +947,70 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"ny" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"nX" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
+"oX" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"tS" = (
-/obj/structure/window/reinforced{
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"pS" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
 	dir = 1;
-	pixel_y = 1
+	name = "Engine Access"
 	},
-/obj/structure/frame/computer{
-	anchored = 1
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"sl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/pod/dark,
-/area/ship/medical)
+/area/ship/security/armory)
+"to" = (
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
 "vB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/recharger,
 /obj/structure/table,
+/obj/machinery/airalarm/all_access{
+	dir = 8;
+	pixel_x = 24
+	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
 "wf" = (
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"wH" = (
+"wP" = (
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"wR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -982,21 +1029,7 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"wP" = (
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"wR" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"ya" = (
+"xW" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/medical)
 "yi" = (
@@ -1018,10 +1051,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
-"yB" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ship/medical)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1037,71 +1066,23 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Cb" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"CG" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
+"CF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Gk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"Jl" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
+"GY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"JT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/power/apc/auto_name/west,
-/obj/structure/cable,
-/obj/machinery/suit_storage_unit/ert/security,
-/turf/open/floor/pod/light,
-/area/ship/security/armory)
-"JX" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"KC" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
-"NP" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/crew/cryo)
-"Oe" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"Of" = (
+"Hh" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
 	},
@@ -1110,17 +1091,52 @@
 	},
 /obj/effect/spawner/structure/window/shuttle,
 /turf/open/floor/plating,
+/area/ship/medical)
+"Hj" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
+"Hl" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
+"Hm" = (
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
 /area/ship/cargo)
-"Ow" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"IA" = (
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
+/obj/structure/frame/computer{
+	anchored = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /turf/open/floor/pod/dark,
+/area/ship/cargo)
+"JT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/apc/auto_name/west,
+/obj/structure/cable,
+/obj/machinery/suit_storage_unit/ert/security,
+/turf/open/floor/pod/light,
 /area/ship/security/armory)
+"Oe" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/ship/cargo)
 "OD" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1145,20 +1161,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"Qk" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
+"OZ" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1172,12 +1177,6 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"TS" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
-"TX" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "Ur" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/west,
@@ -1198,6 +1197,12 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
+"Yb" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
@@ -1212,13 +1217,13 @@ af
 af
 af
 fW
-aQ
-aQ
-aQ
-KC
-KC
-KC
-aQ
+ah
+ah
+ah
+Hm
+Hm
+Hm
+ah
 fW
 af
 af
@@ -1227,37 +1232,37 @@ af
 "}
 (2,1,1) = {"
 af
-et
+nX
 eu
 ex
-eA
+IA
 aa
 ap
 aw
 wP
 bF
-aQ
-aQ
-aQ
+ah
+ah
+ah
 fW
 af
 af
 "}
 (3,1,1) = {"
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
-aQ
+ah
+ah
+ah
+ah
+ah
+ah
+ah
 ax
 aq
 Yj
-aQ
+ah
 RY
 aM
-Qk
+ep
 aH
 af
 "}
@@ -1268,14 +1273,14 @@ af
 af
 af
 af
-Of
+at
 ay
 Oe
 OL
 zw
 dy
 br
-Qk
+ep
 aH
 af
 "}
@@ -1286,15 +1291,15 @@ af
 af
 af
 af
-aQ
+ah
 az
 bx
 bH
-ah
-ah
-ah
-ah
-ah
+aj
+aj
+aj
+aj
+aj
 aR
 "}
 (6,1,1) = {"
@@ -1303,12 +1308,12 @@ af
 af
 as
 aP
-TX
-TX
-TS
-wH
-TS
-ah
+Hj
+Hj
+OZ
+wR
+OZ
+aj
 Gk
 aD
 aF
@@ -1322,25 +1327,25 @@ as
 aE
 aC
 aW
-TX
+Hj
 bg
-gY
+sl
 JT
-ah
+aj
 km
 aN
-ah
-ah
-ah
+aj
+aj
+aj
 "}
 (8,1,1) = {"
 af
 af
-fP
+Hl
 ab
 ae
 bf
-TX
+Hj
 bl
 fY
 ai
@@ -1348,13 +1353,13 @@ aU
 be
 aD
 aG
-Jl
-er
+pS
+oX
 "}
 (9,1,1) = {"
 af
 af
-fP
+Hl
 ac
 ag
 am
@@ -1366,26 +1371,26 @@ mU
 aL
 bP
 bX
-wR
+bY
 aK
 "}
 (10,1,1) = {"
 af
 af
-fP
+Hl
 ad
 ae
 an
-TX
+Hj
 WJ
-Ow
+gY
 bI
-ah
+aj
 bO
 bQ
 bk
-Jl
-er
+pS
+oX
 "}
 (11,1,1) = {"
 af
@@ -1394,16 +1399,16 @@ aA
 aE
 al
 aB
-TX
+Hj
 ek
 bA
 vB
-ah
+aj
 np
 aO
-ah
-ah
-ah
+aj
+aj
+aj
 "}
 (12,1,1) = {"
 af
@@ -1411,13 +1416,13 @@ af
 af
 aA
 aT
-TX
-TX
-TS
+Hj
+Hj
+OZ
 yi
-TS
-ah
-Cb
+OZ
+aj
+GY
 aS
 bZ
 bo
@@ -1430,15 +1435,15 @@ af
 af
 af
 af
-aj
+aQ
 mD
 bB
 Ur
-ah
-ah
-ah
-ah
-ah
+aj
+aj
+aj
+aj
+aj
 aR
 "}
 (14,1,1) = {"
@@ -1448,49 +1453,49 @@ af
 af
 af
 af
-at
+Hh
 eE
 bC
 bJ
 bM
 dU
 aV
-ep
-NP
+mc
+er
 af
 "}
 (15,1,1) = {"
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
 bu
-ny
+CF
 wf
-JX
+ed
 OD
-CG
-ep
-NP
+to
+mc
+er
 af
 "}
 (16,1,1) = {"
 af
-yB
+et
 ew
 ez
-tS
+eA
 ao
 av
 bv
-mO
+Yb
 bK
-JX
-JX
-JX
+ed
+ed
+ed
 df
 af
 af
@@ -1499,14 +1504,14 @@ af
 af
 af
 af
-ya
-aj
-aj
-aj
-aj
-aj
-aj
-JX
+xW
+aQ
+aQ
+aQ
+aQ
+aQ
+aQ
+ed
 df
 af
 af

--- a/_maps/shuttles/shiptest/voidcrew/collins.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/collins.dmm
@@ -40,9 +40,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ae" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/ship/bridge)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/security/armory)
 "af" = (
 /turf/template_noop,
 /area/template_noop)
@@ -53,8 +52,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "ah" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/engineering/engine)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/dark,
+/area/ship/bridge)
 "ai" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -65,7 +65,7 @@
 /area/ship/security/armory)
 "aj" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/cargo)
+/area/ship/engineering/engine)
 "al" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/computer/communications{
@@ -216,9 +216,6 @@
 /turf/open/floor/plating,
 /area/ship/bridge)
 "aB" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
 /obj/machinery/computer/monitor/secret{
 	dir = 8
 	},
@@ -226,6 +223,9 @@
 /obj/machinery/airalarm/all_access{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
@@ -235,9 +235,8 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "aD" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/bridge)
 "aE" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "piratebridge"
@@ -272,7 +271,7 @@
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/cargo)
+/area/ship/engineering/engine)
 "aI" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -373,9 +372,6 @@
 /area/ship/engineering/engine)
 "aS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "aT" = (
@@ -393,21 +389,24 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering/engine)
 "aV" = (
-/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/cryopod,
+/obj/structure/sign/poster/contraband/random{
+	pixel_x = 32
+	},
 /obj/machinery/power/terminal,
 /obj/structure/cable,
 /turf/open/floor/plasteel/dark,
 /area/ship/crew/cryo)
 "aW" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/structure/closet/secure_closet/captains,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/open/floor/plasteel/dark,
 /area/ship/bridge)
 "be" = (
@@ -511,6 +510,25 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
+"bs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor/border_only{
+	dir = 4
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
 "bu" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -738,8 +756,12 @@
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "df" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/crew/cryo)
+/obj/structure/fans/tiny,
+/obj/machinery/door/poddoor{
+	id = "collins_cargo"
+	},
+/turf/open/floor/plating,
+/area/ship/cargo)
 "dy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -794,14 +816,14 @@
 	name = "Engine Access"
 	},
 /turf/open/floor/plating,
-/area/ship/crew/cryo)
+/area/ship/cargo)
 "er" = (
 /obj/machinery/power/shuttle/engine/electric{
 	dir = 1
 	},
 /obj/structure/cable,
 /turf/open/floor/plating,
-/area/ship/engineering/engine)
+/area/ship/crew/cryo)
 "et" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -842,7 +864,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
-/area/ship/medical)
+/area/ship/cargo)
 "eE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -851,23 +873,9 @@
 /obj/structure/table/optable,
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"fO" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "fW" = (
 /turf/closed/wall/mineral/titanium,
-/area/ship/cargo)
+/area/ship/crew/cryo)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -885,12 +893,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
 /turf/open/floor/pod/dark,
 /area/ship/security/armory)
-"ki" = (
+"hh" = (
 /obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
@@ -900,6 +905,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod/dark,
+/area/ship/medical)
+"iL" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/cargo)
 "km" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
@@ -907,6 +915,20 @@
 	pixel_y = 24
 	},
 /obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"ko" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
 "mD" = (
@@ -940,7 +962,63 @@
 	},
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"oP" = (
+"rH" = (
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/cryo)
+"rI" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
+	},
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/medical)
+"sW" = (
+/obj/machinery/power/shuttle/engine/electric{
+	dir = 1
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/ship/cargo)
+"un" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"uv" = (
+/obj/machinery/power/smes/shuttle/precharged{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/crew/cryo)
+"vB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/recharger,
+/obj/structure/table,
+/turf/open/floor/pod/light,
+/area/ship/security/armory)
+"wf" = (
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"wP" = (
+/turf/open/floor/plasteel,
+/area/ship/cargo)
+"wR" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
+"yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -959,91 +1037,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/security/armory)
-"pe" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/medical)
-"tB" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/crew/cryo)
-"uY" = (
-/obj/machinery/power/smes/shuttle/precharged{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
-"vB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/recharger,
-/obj/structure/table,
-/turf/open/floor/pod/light,
-/area/ship/security/armory)
-"wf" = (
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
-"wP" = (
-/turf/open/floor/plasteel,
-/area/ship/cargo)
-"wR" = (
-/turf/closed/wall/mineral/titanium,
-/area/ship/medical)
-"wX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
-"yi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/mining/glass{
-	name = "Cargo Bay"
-	},
-/turf/open/floor/pod/dark,
-/area/ship/security/armory)
-"yQ" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/security/armory)
-"zc" = (
-/obj/machinery/atmospherics/components/unary/shuttle/heater{
-	dir = 1
-	},
-/obj/structure/window/plasma/reinforced/spawner,
-/obj/machinery/door/window/eastright{
-	dir = 1;
-	name = "Engine Access"
-	},
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
 "zw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/decal/cleanable/dirt,
@@ -1059,39 +1052,48 @@
 	},
 /turf/open/floor/wood,
 /area/ship/cargo)
-"Cj" = (
+"Bb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/ship/medical)
+"Bx" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 1
+	},
+/obj/structure/window/plasma/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	dir = 1;
+	name = "Engine Access"
+	},
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"Er" = (
+/obj/machinery/power/apc/auto_name/west,
+/obj/machinery/power/terminal,
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/ship/crew/cryo)
+"EB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/tank/toxins,
+/turf/open/floor/plating,
+/area/ship/engineering/engine)
+"FH" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"Eh" = (
-/obj/structure/fans/tiny,
-/obj/machinery/door/poddoor{
-	id = "collins_cargo"
-	},
-/turf/open/floor/plating,
-/area/ship/cargo)
 "Gk" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/ship/engineering/engine)
-"IF" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/tank/toxins,
-/turf/open/floor/plating,
-/area/ship/engineering/engine)
-"JH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "piratebridge"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/ship/bridge)
+"Gl" = (
+/turf/closed/wall/mineral/titanium,
+/area/ship/medical)
 "JT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -1099,9 +1101,6 @@
 /obj/structure/cable,
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"Ke" = (
-/turf/closed/wall/mineral/titanium/nodiagonal,
-/area/ship/bridge)
 "Oe" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
@@ -1133,12 +1132,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"OZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+"QM" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "piratebridge"
 	},
-/turf/open/floor/plasteel/white,
-/area/ship/medical)
+/obj/machinery/door/firedoor/border_only{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating,
+/area/ship/bridge)
 "RY" = (
 /obj/machinery/airalarm/all_access{
 	pixel_y = 24
@@ -1171,13 +1174,10 @@
 	},
 /turf/open/floor/pod/light,
 /area/ship/security/armory)
-"XL" = (
-/obj/machinery/power/shuttle/engine/electric{
-	dir = 1
-	},
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/ship/crew/cryo)
+"WO" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/ship/cargo)
 "Yj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/south,
@@ -1186,33 +1186,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/ship/cargo)
-"YR" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/ship/cargo)
-"ZD" = (
-/obj/machinery/cryopod,
-/obj/structure/sign/poster/contraband/random{
-	pixel_x = 32
+"Zu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/machinery/power/terminal,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/ship/crew/cryo)
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/pod/dark,
+/area/ship/security/armory)
 
 (1,1,1) = {"
 af
 af
 af
-fW
-aj
-aj
-aj
-Eh
-Eh
-Eh
-aj
-fW
+wR
+iL
+iL
+iL
+df
+df
+df
+iL
+wR
 af
 af
 af
@@ -1220,38 +1220,38 @@ af
 "}
 (2,1,1) = {"
 af
-YR
+WO
 eu
 ex
-ki
+eA
 aa
 ap
 aw
 wP
 bF
-aj
-aj
-aj
-fW
+iL
+iL
+iL
+wR
 af
 af
 "}
 (3,1,1) = {"
-aj
-aj
-aj
-aj
-aj
-aj
-aj
+iL
+iL
+iL
+iL
+iL
+iL
+iL
 ax
 aq
 Yj
-aj
+iL
 RY
 aM
-uY
-aH
+ep
+sW
 af
 "}
 (4,1,1) = {"
@@ -1268,8 +1268,8 @@ OL
 zw
 dy
 br
-uY
-aH
+ep
+sW
 af
 "}
 (5,1,1) = {"
@@ -1279,15 +1279,15 @@ af
 af
 af
 af
-aj
+iL
 az
 bx
 bH
-ah
-ah
-ah
-ah
-ah
+aj
+aj
+aj
+aj
+aj
 aR
 "}
 (6,1,1) = {"
@@ -1296,14 +1296,14 @@ af
 af
 as
 aP
-Ke
-Ke
-yQ
-yi
-yQ
-ah
-Gk
 aD
+aD
+ae
+bs
+ae
+aj
+Gk
+aS
 aF
 aI
 aJ
@@ -1315,39 +1315,39 @@ as
 aE
 aC
 aW
-Ke
+aD
 bg
-gY
+Zu
 JT
-ah
+aj
 km
 aN
-ah
-ah
-ah
+aj
+aj
+aj
 "}
 (8,1,1) = {"
 af
 af
-JH
+QM
 ab
-ae
+ah
 bf
-Ke
+aD
 bl
 fY
 ai
 aU
 be
-aD
+aS
 aG
-fO
-er
+ko
+aH
 "}
 (9,1,1) = {"
 af
 af
-JH
+QM
 ac
 ag
 am
@@ -1359,26 +1359,26 @@ mU
 aL
 bP
 bX
-zc
+Bx
 aK
 "}
 (10,1,1) = {"
 af
 af
-JH
+QM
 ad
-ae
-an
-Ke
-WJ
-wX
-bI
 ah
+an
+aD
+WJ
+gY
+bI
+aj
 bO
 bQ
 bk
-fO
-er
+ko
+aH
 "}
 (11,1,1) = {"
 af
@@ -1387,16 +1387,16 @@ aA
 aE
 al
 aB
-Ke
+aD
 ek
 bA
 vB
-ah
+aj
 np
 aO
-ah
-ah
-ah
+aj
+aj
+aj
 "}
 (12,1,1) = {"
 af
@@ -1404,14 +1404,14 @@ af
 af
 aA
 aT
-Ke
-Ke
-yQ
-oP
-yQ
-ah
-IF
-aS
+aD
+aD
+ae
+yi
+ae
+aj
+EB
+un
 bZ
 bo
 ce
@@ -1427,11 +1427,11 @@ aQ
 mD
 bB
 Ur
-ah
-ah
-ah
-ah
-ah
+aj
+aj
+aj
+aj
+aj
 aR
 "}
 (14,1,1) = {"
@@ -1441,15 +1441,15 @@ af
 af
 af
 af
-pe
+rI
 eE
 bC
 bJ
 bM
 dU
-aV
-ep
-XL
+Er
+uv
+er
 af
 "}
 (15,1,1) = {"
@@ -1461,13 +1461,13 @@ aQ
 aQ
 aQ
 bu
-OZ
+Bb
 wf
-tB
+rH
 OD
-ZD
-ep
-XL
+aV
+uv
+er
 af
 "}
 (16,1,1) = {"
@@ -1475,16 +1475,16 @@ af
 et
 ew
 ez
-eA
+hh
 ao
 av
 bv
-Cj
+FH
 bK
-tB
-tB
-tB
-df
+rH
+rH
+rH
+fW
 af
 af
 "}
@@ -1492,15 +1492,15 @@ af
 af
 af
 af
-wR
+Gl
 aQ
 aQ
 aQ
 aQ
 aQ
 aQ
-tB
-df
+rH
+fW
 af
 af
 af


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<img width="315" alt="image" src="https://github.com/Void-Crew/Voidcrew-LRP/assets/80979251/84331e7b-d9c7-4053-b46a-f54a9a7dca26">
DISCLAIMER:
Is not NEU.
Does not come with SOO gear.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
all the other nanotrasen ships of this side are fucking bubbles

## Changelog
:cl:
add: The NT-C Collins, a light scout ship, has been added.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
