### PR TITLE
updates SOO outfit and adds Special Operations - NT's Diet Deathsquad

### DIFF
--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -31,7 +31,7 @@
 	roles = list(/datum/antagonist/ert/deathsquad)
 	leader_role = /datum/antagonist/ert/deathsquad/leader
 	rename_team = "Deathsquad"
-	code = "Delta"
+	code = "Epsilon"
 	mission = "Leave no witnesses."
 	polldesc = "an elite Nanotrasen Strike Team"
 
@@ -80,3 +80,10 @@
 	mission = "Create entertainment for the crew."
 	polldesc = "a Code Rainbow Nanotrasen Emergency Response Party"
 	code = "Rainbow"
+
+/datum/ert/specops
+	leader_role = /datum/antagonist/ert/specops
+	roles = list(/datum/antagonist/ert/specops)
+	code = "Gamma"
+	mission = "Protect Nanotrasen's interests in the Frontier."
+	polldesc = "a Code Gamma Nanotrasen Special Operations regiment"

--- a/code/modules/antagonists/ert/ert.dm
+++ b/code/modules/antagonists/ert/ert.dm
@@ -80,6 +80,12 @@
 	role = "Trooper"
 	rip_and_tear = TRUE
 
+/datum/antagonist/ert/specops
+	name = "Special Operations Unit"
+	outfit = /datum/outfit/centcom/ert/security/alert/specialops
+	role = "Nanotrasen Spec Ops"
+
+
 /datum/antagonist/ert/medic/inquisitor
 	outfit = /datum/outfit/centcom/ert/medic/inquisitor
 
@@ -185,9 +191,9 @@
 
 	to_chat(owner, "<B><font size=3 color=red>You are the [name].</font></B>")
 
-	var/missiondesc = "Your squad is being sent on a mission to [station_name()] by Nanotrasen's Security Division."
+	var/missiondesc = "Your squad is being sent on a mission to the local sector by Nanotrasen."
 	if(leader) //If Squad Leader
-		missiondesc += " Lead your squad to ensure the completion of the mission. Board the shuttle when your team is ready."
+		missiondesc += " Lead your squad to ensure the completion of the mission. Get in the pod bay when your team is ready." //no ERT shuttles (apart from shuttle)
 	else
 		missiondesc += " Follow orders given to you by your squad leader."
 	if(!rip_and_tear)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -86,6 +86,18 @@
 		/obj/item/melee/baton/loaded=1,\
 		/obj/item/gun/energy/pulse/carbine/loyalpin=1)
 
+/datum/outfit/centcom/ert/security/alert/specialops //diet deathsquad
+	name = "Nanotrasen Special Operations Agent"
+
+	mask = /obj/item/clothing/mask/gas/sechailer/swat
+	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
+		/obj/item/storage/box/handcuffs=1,\
+		/obj/item/melee/baton/loaded=1,\
+		/obj/item/gun/energy/pulse/carbine/loyalpin=1,\
+		/obj/item/storage/firstaid/advanced=1)
+	suit = /obj/item/clothing/suit/space/hardsuit/shielded
+	back = /obj/item/storage/backpack/security
+
 
 /datum/outfit/centcom/ert/medic
 	name = "ERT Medic"

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -8,18 +8,22 @@
 /datum/outfit/centcom/spec_ops
 	name = "Special Ops Officer"
 
-	uniform = /obj/item/clothing/under/syndicate
+	uniform = /obj/item/clothing/under/rank/centcom/commander
 	suit = /obj/item/clothing/suit/space/officer
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/tackler/combat/insulated
-	glasses = /obj/item/clothing/glasses/thermal/eyepatch
+	glasses = /obj/item/clothing/glasses/hud/security/sunglasses/eyepatch
 	ears = /obj/item/radio/headset/headset_cent/commander
 	mask = /obj/item/clothing/mask/cigarette/cigar/havana
 	head = /obj/item/clothing/head/helmet/space/beret
-	belt = /obj/item/gun/energy/pulse/pistol/m1911
-	r_pocket = /obj/item/lighter
+	r_pocket = /obj/item/flashlight/seclite
+	l_pocket = /obj/item/melee/transforming/energy/sword/saber/pirate/blue
 	back = /obj/item/storage/backpack/satchel/leather
 	id = /obj/item/card/id/centcom
+	backpack_contents = list(/obj/item/storage/box/survival/engineer=1,\
+		/obj/item/melee/baton/loaded=1,\
+		/obj/item/gun/energy/pulse/pistol/m1911=1,\
+		/obj/item/storage/firstaid/tactical=1)
 
 /datum/outfit/centcom/spec_ops/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
adds Special Operations from the Adrift Battleship event as a proper ERT type
makes the SOO outfit slightly different

## Why It's Good For The Game

Special Operations is meant to serve as a (vaguely) more balanced deathsquad, the redesigned SOO outfit is solely for my convenience and my convenience alone

## Changelog
:cl:
add: Nanotrasen Special Operations moment
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
