### PR TITLE
Deletes random NT jetpacks (suits have integrated jetpacks) and gives the Thunderbird a much needed facelift

### DIFF
--- a/_maps/shuttles/shiptest/heron.dmm
+++ b/_maps/shuttles/shiptest/heron.dmm
@@ -808,10 +808,7 @@
 	dir = 4;
 	layer = 3.1
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/ert/sec{
-	name = "quick response force hardsuit"
-	},
+/obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "dx" = (
@@ -1020,17 +1017,12 @@
 /turf/open/floor/engine/hull/reinforced/interior,
 /area/ship/maintenance/fore)
 "ek" = (
-/obj/item/gun/energy/e_gun/smg{
-	pixel_y = 9
-	},
-/obj/item/gun/energy/e_gun/smg{
-	pixel_y = 2
-	},
-/obj/item/gun/ballistic/shotgun/automatic/combat{
-	pixel_y = -3
-	},
 /obj/structure/rack,
 /obj/machinery/airalarm/directional/east,
+/obj/item/gun_voucher,
+/obj/item/gun_voucher,
+/obj/item/gun_voucher,
+/obj/item/gun_voucher,
 /turf/open/floor/plasteel/tech,
 /area/ship/security/armory)
 "en" = (
@@ -3139,12 +3131,11 @@
 /turf/open/floor/plasteel/white,
 /area/ship/crew/canteen/kitchen)
 "md" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/decal/cleanable/robot_debris,
+/obj/machinery/suit_storage_unit/ert/engineer,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/hallway/aft)
 "me" = (
@@ -3747,12 +3738,11 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/engineering/atmospherics)
 "oo" = (
-/obj/machinery/suit_storage_unit/inherit,
 /obj/structure/railing{
 	dir = 8;
 	layer = 3.1
 	},
-/obj/item/clothing/suit/space/hardsuit/ert/med,
+/obj/machinery/suit_storage_unit/ert/command,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "oq" = (
@@ -3930,7 +3920,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ship/engineering/atmospherics)
 "oX" = (
-/obj/machinery/suit_storage_unit/inherit,
 /obj/structure/railing{
 	dir = 8;
 	layer = 3.1
@@ -3938,7 +3927,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -28
 	},
-/obj/item/clothing/suit/space/hardsuit/ert/engi,
+/obj/machinery/suit_storage_unit/ert/medical,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "pb" = (
@@ -5796,10 +5785,10 @@
 /turf/open/floor/plasteel/tech,
 /area/ship/engineering/electrical)
 "wx" = (
-/obj/machinery/suit_storage_unit/standard_unit,
 /obj/effect/turf_decal/industrial/warning{
 	dir = 8
 	},
+/obj/machinery/suit_storage_unit/ert/engineer,
 /turf/open/floor/plasteel/patterned/cargo_one,
 /area/ship/hallway/aft)
 "wz" = (
@@ -12037,11 +12026,8 @@
 	dir = 8;
 	layer = 3.1
 	},
-/obj/machinery/suit_storage_unit/inherit,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/clothing/suit/space/hardsuit/ert/sec{
-	name = "quick response force hardsuit"
-	},
+/obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "VH" = (
@@ -12084,10 +12070,7 @@
 	dir = 4;
 	layer = 3.1
 	},
-/obj/machinery/suit_storage_unit/inherit,
-/obj/item/clothing/suit/space/hardsuit/ert/sec{
-	name = "quick response force hardsuit"
-	},
+/obj/machinery/suit_storage_unit/ert/security,
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "VN" = (

--- a/_maps/shuttles/shiptest/scrapper.dmm
+++ b/_maps/shuttles/shiptest/scrapper.dmm
@@ -384,7 +384,7 @@
 /area/ship/engineering/atmospherics)
 "dN" = (
 /obj/structure/catwalk,
-/turf/template_noop,
+/turf/open/floor/plating,
 /area/ship/external)
 "dP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
@@ -510,10 +510,13 @@
 /area/ship/hallway/aft)
 "ft" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
+/obj/item/storage/fancy/donut_box{
+	pixel_y = 8
+	},
 /obj/effect/turf_decal/siding/red{
 	dir = 9
 	},
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "fw" = (
@@ -799,12 +802,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ship/medical)
-"jy" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/ship/external)
 "jC" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -1099,6 +1096,7 @@
 /turf/open/floor/plasteel/tech/techmaint,
 /area/ship/crew/hydroponics)
 "mN" = (
+/obj/structure/catwalk,
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "mR" = (
@@ -1249,6 +1247,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/catwalk,
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "ot" = (
@@ -1570,17 +1569,9 @@
 /turf/open/floor/pod/light,
 /area/ship/hallway/aft)
 "sW" = (
-/obj/structure/closet/wall{
-	dir = 4;
-	name = "armory locker";
-	pixel_x = -32
-	},
 /obj/effect/turf_decal/siding/red{
 	dir = 9
 	},
-/obj/item/gun/energy/laser/terra,
-/obj/item/gun/energy/laser/terra,
-/obj/item/gun/energy/laser/terra,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "tb" = (
@@ -2298,14 +2289,12 @@
 /obj/effect/turf_decal/siding/red{
 	dir = 10
 	},
-/obj/structure/closet/wall{
-	dir = 4;
-	name = "armory locker";
-	pixel_x = -32
-	},
 /obj/machinery/light/dim,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
+/obj/structure/rack,
+/obj/item/gun_voucher/syndicate,
+/obj/item/gun_voucher/syndicate,
+/obj/item/gun_voucher/syndicate,
+/obj/item/gun_voucher/syndicate,
 /turf/open/floor/mineral/plastitanium,
 /area/ship/security)
 "AP" = (
@@ -2353,12 +2342,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer4{
 	dir = 4
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Bh" = (
@@ -2431,12 +2415,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
-	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/pod/light,
 /area/ship/cargo)
 "Ch" = (
@@ -2946,6 +2925,7 @@
 /obj/effect/turf_decal/siding/yellow{
 	dir = 8
 	},
+/obj/structure/catwalk,
 /turf/open/floor/plating/airless,
 /area/ship/external)
 "IC" = (
@@ -2973,12 +2953,6 @@
 /obj/machinery/door/poddoor{
 	id = "scrapdoorext";
 	name = "cargo bay blast door"
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 8
-	},
-/obj/machinery/door/firedoor/border_only{
-	dir = 4
 	},
 /turf/open/floor/pod/light,
 /area/ship/hallway/aft)
@@ -3273,12 +3247,6 @@
 /area/ship/maintenance/starboard)
 "Md" = (
 /turf/open/floor/engine/hull,
-/area/ship/external)
-"Me" = (
-/obj/effect/turf_decal/siding/yellow/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
 /area/ship/external)
 "Mg" = (
 /obj/structure/ore_box,
@@ -5518,11 +5486,11 @@ MX
 qU
 qU
 qU
-jy
+MX
 oo
 oo
 Iw
-Me
+MX
 qU
 qU
 qU
@@ -5764,43 +5732,6 @@ mN
 mN
 mN
 mN
-dN
-qU
-"}
-(31,1,1) = {"
-qU
-qU
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
-dN
 dN
 qU
 "}

--- a/_maps/shuttles/shiptest/voidcrew/bead.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/bead.dmm
@@ -14,6 +14,10 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
+"ce" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium,
+/area/ship/security)
 "ct" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/machinery/light{
@@ -686,6 +690,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/ship/bridge)
+"Ix" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
 "IA" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/effect/turf_decal/siding/thinplating{
@@ -856,6 +864,7 @@
 /turf/closed/wall/mineral/titanium,
 /area/ship/maintenance/aft)
 "Oo" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/ship/engineering)
 "OD" = (
@@ -1422,7 +1431,7 @@ VB
 (10,1,1) = {"
 VB
 gl
-VQ
+ce
 VQ
 VQ
 VQ
@@ -1498,7 +1507,7 @@ Oo
 (14,1,1) = {"
 VB
 VB
-mV
+Ix
 mV
 mV
 oI

--- a/_maps/shuttles/shiptest/voidcrew/indisputable.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/indisputable.dmm
@@ -67,7 +67,6 @@
 	storage_type = /obj/item/tank/jetpack/oxygen
 	},
 /obj/effect/turf_decal/industrial/warning/full,
-/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/hallway/starboard)
 "aC" = (
@@ -2250,7 +2249,6 @@
 	},
 /obj/structure/table/wood/reinforced,
 /obj/machinery/recharger,
-/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "BX" = (
@@ -2597,7 +2595,6 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_gray/diagonal,
 /obj/effect/turf_decal/industrial/warning/full,
-/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Hc" = (
@@ -2866,7 +2863,6 @@
 	storage_type = /obj/item/tank/jetpack/oxygen
 	},
 /obj/effect/turf_decal/industrial/warning/full,
-/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/carpet/nanoweave/red,
 /area/ship/hallway/starboard)
 "Kn" = (
@@ -3529,7 +3525,6 @@
 	},
 /obj/effect/turf_decal/corner_techfloor_gray/diagonal,
 /obj/effect/turf_decal/industrial/warning/full,
-/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "QG" = (

--- a/_maps/shuttles/shiptest/voidcrew/pocketrocket.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/pocketrocket.dmm
@@ -43,6 +43,10 @@
 	layer = 2.49
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/radio/intercom/wideband{
+	pixel_y = 22;
+	pixel_x = 28
+	},
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "bU" = (
@@ -115,6 +119,7 @@
 "hL" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/holopad/emergency/command,
 /turf/open/floor/carpet/black,
 /area/ship/bridge)
 "hS" = (
@@ -141,6 +146,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plating,
 /area/ship/maintenance/central)
 "jp" = (

--- a/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
@@ -18,24 +18,72 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "bL" = (
 /obj/structure/weightmachine/weightlifter,
 /obj/effect/turf_decal/corner/lime/mono,
 /obj/structure/window/reinforced/spawner/east,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/airalarm/directional/north,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "cJ" = (
 /obj/effect/turf_decal/corner/red/mono,
-/obj/machinery/vending/security/marine/solgov,
-/turf/open/floor/mineral/titanium,
+/obj/structure/guncase/shotgun,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/ion,
+/obj/item/ammo_casing/shotgun/laserslug,
+/obj/item/ammo_casing/shotgun/laserslug,
+/obj/item/ammo_casing/shotgun/laserslug,
+/obj/item/ammo_casing/shotgun/laserslug,
+/obj/item/ammo_casing/shotgun/laserslug,
+/obj/item/ammo_casing/shotgun/meteorslug,
+/obj/item/ammo_casing/shotgun/meteorslug,
+/obj/item/ammo_casing/shotgun/meteorslug,
+/obj/item/ammo_casing/shotgun/meteorslug,
+/obj/item/ammo_casing/shotgun/meteorslug,
+/obj/item/ammo_casing/shotgun/pulseslug,
+/obj/item/ammo_casing/shotgun/pulseslug,
+/obj/item/ammo_casing/shotgun/pulseslug,
+/obj/item/ammo_casing/shotgun/pulseslug,
+/obj/item/ammo_casing/shotgun/pulseslug,
+/obj/item/ammo_casing/shotgun/stunslug,
+/obj/item/ammo_casing/shotgun/stunslug,
+/obj/item/ammo_casing/shotgun/stunslug,
+/obj/item/ammo_casing/shotgun/stunslug,
+/obj/item/ammo_casing/shotgun/stunslug,
+/obj/item/ammo_casing/shotgun/incendiary,
+/obj/item/ammo_casing/shotgun/incendiary,
+/obj/item/ammo_casing/shotgun/incendiary,
+/obj/item/ammo_casing/shotgun/incendiary,
+/obj/item/ammo_casing/shotgun/incendiary,
+/obj/item/ammo_casing/shotgun/incapacitate,
+/obj/item/ammo_casing/shotgun/incapacitate,
+/obj/item/ammo_casing/shotgun/incapacitate,
+/obj/item/ammo_casing/shotgun/incapacitate,
+/obj/item/ammo_casing/shotgun/incapacitate,
+/obj/item/ammo_casing/shotgun/frag12,
+/obj/item/ammo_casing/shotgun/frag12,
+/obj/item/ammo_casing/shotgun/frag12,
+/obj/item/ammo_casing/shotgun/frag12,
+/obj/item/ammo_casing/shotgun/frag12,
+/obj/item/ammo_casing/shotgun/dragonsbreath,
+/obj/item/ammo_casing/shotgun/dragonsbreath,
+/obj/item/ammo_casing/shotgun/dragonsbreath,
+/obj/item/ammo_casing/shotgun/dragonsbreath,
+/obj/item/ammo_casing/shotgun/dragonsbreath,
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact/compact,
+/obj/item/gun/ballistic/shotgun/automatic/combat/compact,
+/obj/item/gun/ballistic/shotgun/automatic/combat,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "cM" = (
 /obj/effect/turf_decal/corner/lime/mono,
-/obj/structure/table/reinforced,
-/obj/item/reagent_containers/food/snacks/pizza/meat,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "dh" = (
 /obj/structure/grille,
@@ -48,24 +96,22 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "dy" = (
-/obj/structure/rack,
 /obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/airalarm/directional/south,
-/obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/vending/security/marine/solgov,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "dB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "dH" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/computer/mech_bay_power_console,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "dJ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -75,16 +121,14 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "dK" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dN" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -97,7 +141,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dS" = (
 /obj/structure/grille,
@@ -125,7 +169,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "fy" = (
 /obj/structure/cable{
@@ -133,11 +177,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/corner/lime/mono,
 /obj/machinery/door/airlock{
 	name = "Dormitories"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
 "fC" = (
 /obj/effect/turf_decal/corner/yellow/mono,
@@ -146,14 +189,13 @@
 	name = "Blast Door Control";
 	pixel_x = 24
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "gp" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "gJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -169,7 +211,7 @@
 /area/ship/cargo)
 "hm" = (
 /obj/effect/turf_decal/corner/yellow/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "hx" = (
 /turf/closed/wall/mineral/titanium,
@@ -178,7 +220,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "hU" = (
 /obj/effect/turf_decal/corner/red/mono,
@@ -189,7 +231,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "in" = (
 /obj/structure/cable{
@@ -197,22 +239,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/door/airlock/security/glass,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/security)
 "iq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "iK" = (
 /obj/machinery/computer/autopilot{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "iO" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -229,17 +269,29 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "jc" = (
 /obj/effect/turf_decal/corner/red/mono,
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/obj/item/clothing/mask/gas/sechailer/swat,
-/turf/open/floor/mineral/titanium,
+/obj/structure/table/reinforced,
+/obj/item/crowbar/power,
+/obj/item/crowbar/power{
+	pixel_y = -4
+	},
+/obj/structure/sign/warning/explosives{
+	pixel_x = 32
+	},
+/obj/item/storage/backpack/duffelbag/syndie/c4{
+	icon_state = "duffel-captain";
+	pixel_y = 4;
+	name = "C4 duffel bag"
+	},
+/obj/item/storage/backpack/duffelbag/syndie/c4{
+	icon_state = "duffel-captain";
+	pixel_y = 12;
+	name = "C4 duffel bag"
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "jG" = (
 /obj/structure/cable{
@@ -247,26 +299,26 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "ka" = (
-/obj/machinery/vending/security,
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "kE" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "kW" = (
 /obj/machinery/computer/crew{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "lk" = (
 /obj/effect/turf_decal/corner/yellow/mono,
@@ -275,16 +327,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "lN" = (
 /obj/structure/table/optable,
 /obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "mn" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -296,12 +348,11 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "mR" = (
-/obj/effect/turf_decal/corner/blue/mono,
 /obj/machinery/airalarm/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "nC" = (
 /turf/closed/wall/mineral/titanium,
@@ -312,13 +363,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "nV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "ov" = (
 /obj/structure/table/reinforced,
@@ -335,7 +386,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "oy" = (
 /turf/closed/wall/mineral/titanium,
@@ -359,7 +410,7 @@
 /obj/machinery/suit_storage_unit/ert/security{
 	storage_type = /obj/item/tank/jetpack/oxygen
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "po" = (
 /obj/structure/cable{
@@ -371,20 +422,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "pq" = (
 /obj/machinery/computer/operating,
 /obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "pG" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/bridge)
 "pO" = (
-/obj/effect/turf_decal/corner/blue/mono,
 /obj/machinery/suit_storage_unit/ert/command,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "pR" = (
 /obj/effect/turf_decal/corner/red/mono,
@@ -398,7 +448,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "qh" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -416,7 +466,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "qu" = (
 /obj/machinery/power/terminal{
@@ -437,8 +487,26 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/mineral/titanium,
+/obj/structure/table/reinforced,
+/obj/item/clothing/glasses/hud/toggle/thermal{
+	pixel_y = 5
+	},
+/obj/item/clothing/glasses/hud/toggle/thermal{
+	pixel_y = -5
+	},
+/obj/item/clothing/glasses/hud/toggle/thermal{
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/hud/toggle/thermal{
+	pixel_y = -3
+	},
+/obj/item/clothing/glasses/hud/toggle/thermal,
+/obj/item/clothing/mask/gas/welding,
+/obj/item/clothing/mask/gas/welding,
+/obj/item/clothing/mask/gas/welding,
+/obj/item/clothing/mask/gas/welding,
+/obj/item/clothing/mask/gas/welding,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "rk" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -454,12 +522,11 @@
 	req_access = null
 	},
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "sZ" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "td" = (
 /obj/structure/cable{
@@ -477,7 +544,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tj" = (
 /obj/item/reagent_containers/food/snacks/canned/beans{
@@ -513,14 +580,21 @@
 /obj/item/reagent_containers/food/snacks/rationpack,
 /obj/item/reagent_containers/food/snacks/rationpack,
 /obj/effect/turf_decal/corner/lime/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "tp" = (
 /turf/closed/wall/mineral/titanium,
 /area/ship/cargo)
 "tr" = (
 /obj/effect/turf_decal/corner/lime/mono,
-/turf/open/floor/mineral/titanium,
+/obj/structure/window/reinforced/spawner/east,
+/obj/structure/table/wood,
+/obj/item/storage/cans/sixbeer,
+/obj/item/storage/cans/sixbeer,
+/obj/item/kitchen/knife/plastic,
+/obj/item/pizzabox/meat,
+/obj/item/pizzabox/pineapple,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "tD" = (
 /obj/structure/cable{
@@ -532,7 +606,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
@@ -540,27 +614,27 @@
 /obj/machinery/suit_storage_unit/ert/security{
 	storage_type = /obj/item/tank/jetpack/oxygen
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "uj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "ur" = (
 /obj/machinery/door/airlock/maintenance_hatch,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/maintenance/aft)
 "uD" = (
 /obj/machinery/stasis,
@@ -568,7 +642,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "uF" = (
 /turf/closed/wall/mineral/titanium,
@@ -589,7 +663,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "wd" = (
 /obj/effect/turf_decal/corner/red/mono,
@@ -598,7 +672,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "wl" = (
 /obj/machinery/power/smes/engineering,
@@ -622,11 +696,10 @@
 /area/ship/maintenance/aft)
 "ww" = (
 /obj/effect/turf_decal/corner/lime/mono,
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/cans/sixbeer,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/mineral/titanium,
+/obj/structure/chair/sofa/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "ya" = (
 /obj/machinery/power/terminal{
@@ -640,7 +713,7 @@
 /area/ship/maintenance/aft)
 "ym" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "zq" = (
 /turf/template_noop,
@@ -648,7 +721,6 @@
 "zv" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/effect/turf_decal/corner/blue/mono,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -656,7 +728,7 @@
 /obj/item/radio/intercom/wideband{
 	pixel_x = -26
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "zE" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -681,18 +753,18 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Aa" = (
 /obj/machinery/cryopod{
 	dir = 4
 	},
 /obj/effect/turf_decal/corner/lime/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "AA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "BS" = (
 /obj/machinery/power/terminal{
@@ -709,7 +781,7 @@
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
 /obj/item/t_scanner/adv_mining_scanner/lesser,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Cu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -717,12 +789,12 @@
 	},
 /obj/effect/turf_decal/corner/red/mono,
 /obj/structure/tank_dispenser/oxygen,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Cv" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/airalarm/directional/west,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Dd" = (
 /obj/structure/cable{
@@ -732,13 +804,13 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Dk" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Dy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
@@ -747,7 +819,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Ei" = (
 /obj/structure/rack,
@@ -757,27 +829,27 @@
 /obj/item/storage/firstaid/advanced,
 /obj/effect/turf_decal/corner/blue/mono,
 /obj/item/defibrillator/loaded,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "EN" = (
 /obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Fc" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Ff" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/mech_bay_recharge_port{
 	dir = 2
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Gm" = (
 /obj/machinery/power/apc/auto_name/north,
@@ -785,23 +857,22 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/holopad/emergency/command,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "Gw" = (
 /obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/suit_storage_unit/ert/security{
 	storage_type = /obj/item/tank/jetpack/oxygen
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Gy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "GG" = (
-/obj/effect/turf_decal/corner/blue/mono,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -811,7 +882,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "GY" = (
 /obj/machinery/power/terminal{
@@ -829,13 +900,8 @@
 "HM" = (
 /obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/airalarm/directional/south,
-/obj/structure/rack,
-/obj/item/tank/jetpack/oxygen/security,
-/obj/item/tank/jetpack/oxygen/security,
-/obj/item/tank/jetpack/oxygen/security,
-/obj/item/tank/jetpack/oxygen/security,
-/obj/item/tank/jetpack/oxygen/security,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Ij" = (
 /obj/structure/cable{
@@ -863,7 +929,7 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "Iv" = (
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "IW" = (
 /obj/machinery/power/smes/shuttle/precharged{
@@ -876,23 +942,28 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
+"JS" = (
+/obj/structure/table/reinforced,
+/obj/item/gun/ballistic/revolver/russian,
+/obj/item/ammo_box/a357,
+/turf/open/floor/plasteel/patterned,
+/area/ship/security/armory)
 "Km" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/corner/red/mono,
-/obj/item/gun_voucher/solgov,
-/obj/item/gun_voucher/solgov,
 /obj/item/gun_voucher,
-/turf/open/floor/mineral/titanium,
+/obj/item/gun_voucher,
+/obj/item/gun_voucher,
+/obj/item/gun_voucher,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "KW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/obj/structure/chair/sofa/corner,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "KX" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
 	},
@@ -900,7 +971,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Lw" = (
 /obj/structure/cable{
@@ -914,7 +985,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "LK" = (
 /obj/machinery/power/am_control_unit,
@@ -933,7 +1004,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "MC" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
@@ -957,10 +1028,9 @@
 /area/ship/external)
 "Ns" = (
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "NT" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -968,7 +1038,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Oa" = (
 /obj/machinery/power/shuttle/engine/electric{
@@ -986,13 +1056,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "OQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "OZ" = (
 /obj/structure/cable{
@@ -1001,26 +1071,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/door/airlock/mining/glass,
-/obj/effect/turf_decal/corner/yellow/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Pc" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Pp" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "PN" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/airalarm/directional/north,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Qb" = (
 /obj/structure/cable{
@@ -1041,14 +1107,16 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "SC" = (
 /obj/effect/turf_decal/corner/lime/mono,
 /obj/machinery/computer/cryopod{
 	pixel_y = 32
 	},
-/turf/open/floor/mineral/titanium,
+/obj/machinery/cell_charger,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "SG" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1059,10 +1127,10 @@
 	piping_layer = 4
 	},
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "SS" = (
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Tj" = (
 /obj/structure/cable{
@@ -1074,9 +1142,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
-/obj/effect/turf_decal/corner/blue/mono,
 /obj/machinery/door/airlock/command/glass,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/bridge)
 "TK" = (
 /turf/closed/wall/mineral/titanium/nodiagonal,
@@ -1087,40 +1154,38 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Vg" = (
-/obj/effect/turf_decal/corner/red/mono,
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/turf/open/floor/mineral/titanium,
-/area/ship/security/armory)
+/obj/effect/turf_decal/corner/yellow/mono,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/pod,
+/area/ship/cargo)
 "Vi" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/ore_silo,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Vl" = (
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Vs" = (
 /obj/effect/turf_decal/corner/blue/mono,
 /obj/structure/closet/crate/freezer/blood,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Vx" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/light,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "VV" = (
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Wp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Ww" = (
 /obj/machinery/am_shielding,
@@ -1146,21 +1211,21 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Xc" = (
 /obj/effect/turf_decal/corner/lime/mono,
 /obj/structure/chair/sofa/corner{
 	dir = 4
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Xr" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/corner/red/mono,
 /obj/item/gun/energy/e_gun,
 /obj/item/gun/energy/e_gun,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Xz" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -1187,7 +1252,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "XU" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -1203,43 +1268,41 @@
 /turf/open/floor/mineral/titanium,
 /area/ship/cargo)
 "Yp" = (
-/obj/effect/turf_decal/corner/bottlegreen/mono,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Yv" = (
 /obj/effect/turf_decal/corner/blue/mono,
 /obj/machinery/suit_storage_unit/ert/medical,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "YX" = (
 /obj/machinery/computer/helm{
 	dir = 8
 	},
-/obj/effect/turf_decal/corner/blue/mono,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "YY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Zd" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Zg" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/autolathe,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/pod,
 /area/ship/cargo)
 "Zp" = (
 /obj/structure/cable{
@@ -1249,9 +1312,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/effect/turf_decal/corner/red/mono,
 /obj/machinery/door/airlock/security/glass,
-/turf/open/floor/mineral/titanium,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/security/armory)
 "Zy" = (
 /obj/structure/grille,
@@ -1268,16 +1330,18 @@
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "ZX" = (
-/obj/structure/rack,
-/obj/item/gun/energy/beam_rifle{
-	pin = /obj/item/firing_pin
-	},
-/obj/item/gun/energy/beam_rifle{
-	pin = /obj/item/firing_pin
-	},
 /obj/effect/turf_decal/corner/red/mono,
-/turf/open/floor/mineral/titanium,
+/obj/machinery/vending/security,
+/turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
+"ZY" = (
+/obj/effect/turf_decal/corner/lime/mono,
+/obj/structure/table/reinforced,
+/obj/item/kitchen/knife/plastic,
+/obj/item/storage/cans/sixbeer,
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/mineral/titanium,
+/area/template_noop)
 
 (1,1,1) = {"
 zq
@@ -1439,13 +1503,13 @@ oy
 ur
 oy
 TK
-Vg
-VV
+ka
+JS
 vN
 VV
 Km
 nC
-zq
+ZY
 "}
 (9,1,1) = {"
 MH
@@ -1508,7 +1572,7 @@ ov
 tj
 Xc
 ww
-uF
+dS
 "}
 (12,1,1) = {"
 hc
@@ -1529,7 +1593,7 @@ Iv
 iq
 KW
 cM
-dS
+oO
 "}
 (13,1,1) = {"
 hc
@@ -1550,7 +1614,7 @@ dB
 un
 Iv
 tr
-oO
+dS
 "}
 (14,1,1) = {"
 hc
@@ -1571,7 +1635,7 @@ Iv
 Iv
 Iv
 Ei
-dS
+uF
 "}
 (15,1,1) = {"
 hc
@@ -1601,7 +1665,7 @@ SG
 WY
 Cj
 Vl
-hm
+Vg
 SG
 pG
 Tj

--- a/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
@@ -1334,14 +1334,6 @@
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
-"ZY" = (
-/obj/effect/turf_decal/corner/lime/mono,
-/obj/structure/table/reinforced,
-/obj/item/kitchen/knife/plastic,
-/obj/item/storage/cans/sixbeer,
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/mineral/titanium,
-/area/template_noop)
 
 (1,1,1) = {"
 zq
@@ -1509,7 +1501,7 @@ vN
 VV
 Km
 nC
-ZY
+zq
 "}
 (9,1,1) = {"
 MH

--- a/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
+++ b/_maps/shuttles/shiptest/voidcrew/thunderbird.dmm
@@ -6,6 +6,17 @@
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 10
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood{
+	pixel_y = 32;
+	layer = 12
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "bk" = (
@@ -18,6 +29,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "bL" = (
@@ -106,6 +118,7 @@
 /area/ship/security/armory)
 "dB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "dH" = (
@@ -118,11 +131,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "dK" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dN" = (
@@ -141,6 +156,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "dS" = (
@@ -169,8 +185,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
+"fa" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/garbage,
+/turf/open/floor/plasteel/patterned,
+/area/ship/crew/dorm)
 "fy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -183,18 +205,20 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
 "fC" = (
-/obj/effect/turf_decal/corner/yellow/mono,
 /obj/machinery/button/door{
 	id = "cargodoors";
 	name = "Blast Door Control";
 	pixel_x = 24
 	},
+/obj/effect/turf_decal/industrial/caution,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "gp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "gJ" = (
@@ -207,10 +231,16 @@
 	name = "cargo bay blast door"
 	},
 /obj/structure/fans/tiny,
+/obj/effect/turf_decal/industrial/hatch/yellow,
 /turf/open/floor/plating,
 /area/ship/cargo)
+"hg" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned,
+/area/ship/crew/dorm)
 "hm" = (
-/obj/effect/turf_decal/corner/yellow/mono,
+/obj/effect/turf_decal/industrial/loading,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "hx" = (
@@ -220,6 +250,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "hU" = (
@@ -231,6 +262,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "in" = (
@@ -246,8 +278,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
+"iD" = (
+/obj/effect/turf_decal/industrial/loading,
+/obj/structure/sign/warning/vacuum{
+	pixel_x = -32
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/ship/cargo)
 "iK" = (
 /obj/machinery/computer/autopilot{
 	dir = 8
@@ -262,6 +303,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "iY" = (
@@ -293,12 +335,22 @@
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
+"ji" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned,
+/area/ship/hallway/central)
 "jG" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "ka" = (
@@ -307,19 +359,35 @@
 /obj/machinery/recharger,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
+"kf" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/cargo)
 "kE" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "kW" = (
 /obj/machinery/computer/crew{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
+"lc" = (
+/obj/effect/turf_decal/corner/red/mono,
+/obj/machinery/suit_storage_unit/ert/security{
+	storage_type = /obj/item/tank/jetpack/oxygen
+	},
+/obj/structure/sign/poster/official{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/security)
 "lk" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/structure/cable{
@@ -336,6 +404,7 @@
 /area/ship/crew/dorm)
 "me" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "mn" = (
@@ -345,6 +414,23 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/industrial/radiation,
+/obj/effect/decal/cleanable/blood/old{
+	dir = 8;
+	icon_state = "trails_1";
+	name = "dried blood trail"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood{
+	pixel_y = 32;
+	layer = 12
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "mR" = (
@@ -352,6 +438,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/glass,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "nC" = (
@@ -369,6 +456,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "ov" = (
@@ -402,7 +490,7 @@
 	port_direction = 8;
 	preferred_direction = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/tech/grid,
 /area/ship/crew/dorm)
 "oU" = (
 /obj/effect/turf_decal/corner/red/mono,
@@ -422,6 +510,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "pq" = (
@@ -434,6 +523,10 @@
 /area/ship/bridge)
 "pO" = (
 /obj/machinery/suit_storage_unit/ert/command,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "pR" = (
@@ -448,6 +541,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "qh" = (
@@ -460,12 +554,17 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "qj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "qu" = (
@@ -478,8 +577,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/item/tank/jetpack/suit,
-/obj/structure/rack,
+/obj/effect/turf_decal/industrial/radiation,
+/obj/machinery/suit_storage_unit/radsuit,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "qJ" = (
@@ -515,17 +615,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/blood/old{
+	dir = 10;
+	icon_state = "trails_1";
+	name = "dried blood trail"
+	},
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "su" = (
-/obj/structure/closet/secure_closet/lethalshots{
-	req_access = null
-	},
 /obj/effect/turf_decal/corner/red/mono,
+/obj/structure/closet/secure_closet/captains,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "sZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "td" = (
@@ -544,6 +654,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tj" = (
@@ -580,6 +691,8 @@
 /obj/item/reagent_containers/food/snacks/rationpack,
 /obj/item/reagent_containers/food/snacks/rationpack,
 /obj/effect/turf_decal/corner/lime/mono,
+/obj/item/storage/bag/trash,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "tp" = (
@@ -594,6 +707,8 @@
 /obj/item/kitchen/knife/plastic,
 /obj/item/pizzabox/meat,
 /obj/item/pizzabox/pineapple,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/food/flour,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "tD" = (
@@ -606,6 +721,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "tQ" = (
@@ -621,12 +737,14 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "un" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 9
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "ur" = (
@@ -657,12 +775,17 @@
 /obj/machinery/atmospherics/pipe/manifold/orange/visible{
 	dir = 8
 	},
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "vN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "wd" = (
@@ -672,6 +795,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "wl" = (
@@ -692,6 +816,16 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/effect/turf_decal/industrial/radiation,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/gibs/core,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "ww" = (
@@ -708,26 +842,40 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/suit_storage_unit/independent/engineering,
+/obj/machinery/suit_storage_unit/ert/engineer,
+/obj/item/tank/internals/oxygen,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "ym" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
+"yK" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium,
+/area/ship/crew/dorm)
 "zq" = (
 /turf/template_noop,
 /area/template_noop)
 "zv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/item/gun/energy/laser/captain,
 /obj/item/radio/intercom/wideband{
 	pixel_x = -26
 	},
+/obj/machinery/photocopier/faxmachine/longrange{
+	layer = 3.1;
+	pixel_y = 6;
+	pixel_x = -4
+	},
+/obj/item/paper_bin{
+	pixel_y = 4;
+	pixel_x = 8
+	},
+/obj/item/pen/fountain,
+/obj/item/pen/fourcolor,
+/obj/item/stamp/captain,
+/obj/item/reagent_containers/food/drinks/bottle/lizardwine,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "zE" = (
@@ -737,6 +885,10 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "zL" = (
@@ -746,6 +898,8 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
+/obj/effect/decal/cleanable/blood/gibs/bubblegum,
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "zQ" = (
@@ -753,6 +907,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Aa" = (
@@ -762,8 +917,14 @@
 /obj/effect/turf_decal/corner/lime/mono,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
+"Ao" = (
+/obj/machinery/light,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/patterned,
+/area/ship/hallway/central)
 "AA" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "BS" = (
@@ -774,6 +935,11 @@
 /obj/machinery/power/port_gen/pacman,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
+"BZ" = (
+/obj/effect/turf_decal/industrial/caution,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/pod,
+/area/ship/cargo)
 "Cj" = (
 /obj/effect/turf_decal/corner/yellow/mono,
 /obj/structure/rack,
@@ -796,6 +962,18 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/pod,
 /area/ship/cargo)
+"Cy" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/aft)
 "Dd" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -804,12 +982,13 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Dk" = (
-/obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/corner/red/mono,
+/obj/structure/closet/secure_closet/hos,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Dy" = (
@@ -836,12 +1015,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Fc" = (
 /obj/structure/table/reinforced,
 /obj/item/storage/backpack/duffelbag/med/surgery,
 /obj/effect/turf_decal/corner/blue/mono,
+/obj/structure/sign/warning/nosmoking{
+	pixel_x = 32
+	},
+/obj/item/soap{
+	pixel_y = 8
+	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "Ff" = (
@@ -851,12 +1037,17 @@
 	},
 /turf/open/floor/pod,
 /area/ship/cargo)
+"Ft" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/mineral/titanium,
+/area/ship/maintenance/aft)
 "Gm" = (
 /obj/machinery/power/apc/auto_name/north,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/holopad/emergency/command,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "Gw" = (
@@ -882,6 +1073,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "GY" = (
@@ -895,6 +1087,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/port_gen/pacman,
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "HM" = (
@@ -907,6 +1102,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "Im" = (
@@ -942,6 +1138,17 @@
 	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
+"JL" = (
+/obj/machinery/atmospherics/components/unary/shuttle/heater{
+	dir = 4
+	},
+/obj/structure/window/reinforced/spawner/west,
+/obj/machinery/door/window/eastright,
+/obj/structure/sign/poster/official/the_owl{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/ship/maintenance/aft)
 "JS" = (
 /obj/structure/table/reinforced,
 /obj/item/gun/ballistic/revolver/russian,
@@ -961,6 +1168,8 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/generic,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "KX" = (
@@ -985,6 +1194,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "LK" = (
@@ -1004,6 +1214,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "MC" = (
@@ -1014,6 +1225,10 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "MH" = (
@@ -1028,8 +1243,14 @@
 /area/ship/external)
 "Ns" = (
 /obj/effect/turf_decal/corner/red/mono,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
+"NH" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/greenglow,
+/turf/open/floor/pod,
+/area/ship/cargo)
 "NT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1038,6 +1259,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Oa" = (
@@ -1056,12 +1278,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/effect/decal/cleanable/garbage,
 /turf/open/floor/plasteel/patterned,
 /area/ship/crew/dorm)
 "OQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "OZ" = (
@@ -1074,6 +1298,7 @@
 /turf/open/floor/plasteel/tech/grid,
 /area/ship/cargo)
 "Pc" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Pp" = (
@@ -1086,6 +1311,7 @@
 /area/ship/hallway/central)
 "PN" = (
 /obj/machinery/airalarm/directional/north,
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
 "Qb" = (
@@ -1099,6 +1325,26 @@
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/clothing/gloves/color/yellow,
+/obj/effect/decal/cleanable/dirt/dust,
+/turf/open/floor/plating,
+/area/ship/maintenance/aft)
+"Ri" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/blood/old{
+	icon_state = "trails_1";
+	name = "dried blood trail"
+	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/blood/footprints,
+/obj/effect/decal/cleanable/blood/footprints{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "Ss" = (
@@ -1107,6 +1353,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "SC" = (
@@ -1130,6 +1377,7 @@
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "SS" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Tj" = (
@@ -1154,6 +1402,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security)
 "Vg" = (
@@ -1167,6 +1416,7 @@
 /turf/open/floor/pod,
 /area/ship/cargo)
 "Vl" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "Vs" = (
@@ -1178,23 +1428,39 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
+"VH" = (
+/obj/effect/turf_decal/corner/red/mono,
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/obj/structure/sign/poster/official{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/patterned,
+/area/ship/security/armory)
 "VV" = (
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "Wp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 6
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "Ww" = (
 /obj/machinery/am_shielding,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
+"WG" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium,
+/area/ship/cargo)
 "WR" = (
 /obj/machinery/atmospherics/components/unary/tank/toxins{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "WY" = (
@@ -1236,6 +1502,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "XH" = (
@@ -1243,6 +1510,17 @@
 	dir = 8
 	},
 /obj/structure/cable,
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/structure/chair/plastic{
+	dir = 8
+	},
+/obj/item/storage/fancy/cigarettes/cigars,
+/obj/item/storage/fancy/cigarettes/cigpack_cannabis,
+/obj/item/storage/fancy/cigarettes/cigpack_robustgold,
+/obj/item/storage/fancy/cigarettes/cigpack_uplift,
+/obj/item/lighter/greyscale,
+/obj/item/lighter/greyscale,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "XM" = (
@@ -1252,6 +1530,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
 "XU" = (
@@ -1261,6 +1540,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/effect/turf_decal/industrial/radiation{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/dirt/dust,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "Yh" = (
@@ -1270,6 +1553,11 @@
 "Yp" = (
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/xenoblood/xsplatter{
+	pixel_y = 32;
+	layer = 78
 	},
 /turf/open/floor/plasteel/patterned,
 /area/ship/hallway/central)
@@ -1282,12 +1570,15 @@
 /obj/machinery/computer/helm{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/carpet/executive,
 /area/ship/bridge)
 "YY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/oil/slippery,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "Zd" = (
@@ -1295,6 +1586,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/pod,
 /area/ship/cargo)
 "Zg" = (
@@ -1327,6 +1619,8 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/effect/decal/cleanable/dirt/dust,
+/obj/effect/decal/cleanable/ash,
 /turf/open/floor/plating,
 /area/ship/maintenance/aft)
 "ZX" = (
@@ -1334,6 +1628,10 @@
 /obj/machinery/vending/security,
 /turf/open/floor/plasteel/patterned,
 /area/ship/security/armory)
+"ZY" = (
+/obj/structure/sign/poster/official/nanotrasen_logo,
+/turf/closed/wall/mineral/titanium/nodiagonal,
+/area/ship/crew/dorm)
 
 (1,1,1) = {"
 zq
@@ -1382,7 +1680,7 @@ zq
 zq
 oy
 IW
-eO
+JL
 oy
 ya
 qu
@@ -1404,8 +1702,8 @@ zq
 Zy
 zL
 rk
-dJ
-iO
+Cy
+Ri
 wp
 Ww
 Ww
@@ -1464,7 +1762,7 @@ zq
 (7,1,1) = {"
 zq
 hx
-Gw
+lc
 me
 AA
 Dk
@@ -1475,7 +1773,7 @@ Ij
 Qb
 TK
 TK
-ka
+VH
 qj
 VV
 ZX
@@ -1493,7 +1791,7 @@ su
 TK
 oy
 ur
-oy
+Ft
 TK
 ka
 JS
@@ -1543,10 +1841,10 @@ uF
 uF
 uF
 aJ
-uF
+yK
 "}
 (11,1,1) = {"
-tp
+WG
 SG
 tp
 tp
@@ -1568,8 +1866,8 @@ dS
 "}
 (12,1,1) = {"
 hc
-hm
-hm
+iD
+BZ
 nD
 Ff
 Cv
@@ -1580,7 +1878,7 @@ td
 dK
 uF
 SC
-Iv
+hg
 Iv
 iq
 KW
@@ -1590,21 +1888,21 @@ oO
 (13,1,1) = {"
 hc
 hm
-Vl
+NH
 Vl
 Wp
 uj
 lk
 OZ
-Pp
+ji
 Lw
-Pp
+ji
 fy
 OI
 Dd
 dB
 un
-Iv
+fa
 tr
 dS
 "}
@@ -1619,12 +1917,12 @@ Zd
 Yh
 Pc
 tD
-Vx
+Ao
 uF
 bL
 LT
-Iv
-Iv
+hg
+hg
 Iv
 Ei
 uF
@@ -1651,7 +1949,7 @@ Vs
 uF
 "}
 (16,1,1) = {"
-tp
+WG
 tp
 SG
 WY
@@ -1669,7 +1967,7 @@ Fc
 Yv
 aJ
 uF
-uF
+yK
 "}
 (17,1,1) = {"
 zq
@@ -1742,11 +2040,11 @@ zq
 zq
 zq
 zq
-SG
+kf
 dh
 dh
 dh
-aJ
+ZY
 zq
 zq
 zq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Some NT ships had jetpacks laying around everywhere even though the ERT suits that NT get all have integrated jetpacks.
I also gave the Thunderbird a facelift and gave the Heron the ERT suits instead of whatever it had before (for standardization)

## Why It's Good For The Game

Lessens clutter and makes the Thunderbird a more viable ship choice


