### PR TITLE
wires alpha station so you dont have to tear out the nt rep's floors …

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3395,6 +3395,14 @@
 /obj/structure/dresser,
 /turf/open/floor/holofloor/carpet,
 /area/holodeck/rec_center/photobooth)
+"att" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/hall)
 "atx" = (
 /obj/item/storage/pill_bottle/dice,
 /obj/structure/table/wood/fancy/green,
@@ -5072,6 +5080,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -12229,6 +12240,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/biolab)
+"bgR" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/cargo)
 "bhG" = (
 /obj/structure/bed,
 /obj/item/bedsheet/nanotrasen,
@@ -12314,6 +12332,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "bmt" = (
@@ -12366,8 +12387,14 @@
 	auto_name = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /mob/living/simple_animal/hostile/carp,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "brq" = (
@@ -13207,6 +13234,16 @@
 /obj/effect/turf_decal/borderfloor,
 /turf/open/floor/mineral/titanium,
 /area/syndicate_mothership/control)
+"cfp" = (
+/obj/effect/turf_decal/corner/green/diagonal_centre{
+	color = "#66b266"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/dark/diagonal,
+/area/ruin/space/ancientstation/alpha/office)
 "cfx" = (
 /obj/machinery/power/port_gen/pacman/uranium{
 	name = "\improper emergency power generator"
@@ -13769,6 +13806,9 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "cFA" = (
@@ -13799,6 +13839,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "cFH" = (
@@ -14443,6 +14486,9 @@
 	},
 /obj/effect/turf_decal/corner/blue/diagonal_centre,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/alpha/arrivals)
 "dcv" = (
@@ -14779,6 +14825,9 @@
 "dwq" = (
 /obj/structure/door_assembly/door_assembly_public,
 /obj/effect/decal/cleanable/glass,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "dwS" = (
@@ -14909,6 +14958,9 @@
 	auto_name = 0
 	},
 /obj/machinery/firealarm/east,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/alpha/comdorms)
 "dCH" = (
@@ -15146,6 +15198,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -16088,6 +16143,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "eAl" = (
@@ -16215,6 +16273,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "eEN" = (
@@ -16244,6 +16305,9 @@
 /obj/structure/fans/tiny/invisible,
 /obj/effect/turf_decal/corner/blue/diagonal_centre,
 /obj/machinery/door/firedoor/closed,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/alpha/arrivals)
 "eFZ" = (
@@ -16448,6 +16512,9 @@
 /obj/item/stack/sheet/mineral/wood,
 /obj/structure/table/wood,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/wood/airless,
 /area/ruin/space/ancientstation/alpha/library)
 "eNf" = (
@@ -16488,6 +16555,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -16666,15 +16739,15 @@
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/beta/hall)
 "eYG" = (
+/obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
-	dir = 4
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
 	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/ancientstation/alpha/hall)
+/area/ruin/space/ancientstation/alpha/lounge)
 "eZl" = (
 /obj/structure/catwalk,
 /obj/structure/cable/yellow{
@@ -16732,6 +16805,9 @@
 	name = "Alpha Station Lounge APC";
 	start_charge = 0;
 	auto_name = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/lounge)
@@ -16827,6 +16903,9 @@
 "fhy" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "fhZ" = (
@@ -17066,6 +17145,9 @@
 	icon_state = "pile"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg3"
 	},
@@ -17627,6 +17709,13 @@
 /obj/item/clothing/gloves/color/yellow,
 /turf/open/floor/plating,
 /area/ruin/space/ancientstation/beta/hall)
+"fUi" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/hall)
 "fUo" = (
 /obj/machinery/light/small{
 	brightness = 3;
@@ -17670,6 +17759,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -18427,6 +18519,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
 /area/ruin/space/ancientstation/delta/rnd)
+"gCB" = (
+/obj/effect/turf_decal/corner/blue/diagonal_centre,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron/diagonal,
+/area/ruin/space/ancientstation/alpha/arrivals)
 "gEY" = (
 /obj/item/shard,
 /obj/structure/fluff/broken_flooring{
@@ -18898,6 +18998,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "gZx" = (
@@ -20285,6 +20388,12 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -21908,6 +22017,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "jJq" = (
@@ -22167,6 +22279,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /mob/living/simple_animal/hostile/carp,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "jRS" = (
@@ -22237,6 +22352,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/library)
@@ -22359,6 +22477,9 @@
 /obj/item/trash/boritos,
 /obj/item/trash/raisins,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/alpha/arrivals)
 "ked" = (
@@ -22902,6 +23023,9 @@
 	name = "Alpha Station Docks APC";
 	start_charge = 0;
 	auto_name = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/alpha/arrivals)
@@ -23755,6 +23879,17 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/pet_lounge)
+"llb" = (
+/obj/item/shard,
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg1"
+	},
+/area/ruin/space/ancientstation/alpha/library)
 "lml" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/white,
@@ -23896,6 +24031,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -24184,6 +24322,7 @@
 /area/ruin/space/ancientstation/charlie/hall)
 "lEN" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -24664,6 +24803,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -26
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -24793,6 +24935,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "mhF" = (
@@ -25652,6 +25800,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "mRs" = (
@@ -25689,6 +25840,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -25772,6 +25926,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/engine/airless,
 /area/ruin/space/ancientstation/beta/supermatter)
+"mWl" = (
+/obj/item/kirbyplants{
+	icon_state = "plant-25"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/iron,
+/area/ruin/space/ancientstation/alpha/comdorms)
 "mWm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/yellow{
@@ -26314,6 +26478,9 @@
 	color = "#3d3c38"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/alpha/comdorms)
 "nuP" = (
@@ -27387,6 +27554,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/alpha/comdorms)
 "oxU" = (
@@ -27615,6 +27785,17 @@
 /obj/item/trash/energybar,
 /turf/open/floor/plating/dirt,
 /area/centcom/exterior)
+"oKt" = (
+/obj/machinery/door/airlock/mining/glass{
+	name = "Cargo Bay"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/cargo)
 "oKG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4,
 /obj/effect/decal/cleanable/dirt,
@@ -27655,6 +27836,9 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -27982,6 +28166,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/ancientstation/alpha/office)
 "oYG" = (
@@ -28134,6 +28321,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/alpha/comdorms)
 "pfQ" = (
@@ -28647,6 +28837,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -30079,6 +30272,19 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
+"qJT" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/hall)
 "qJZ" = (
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership/elite_squad)
@@ -30984,6 +31190,9 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/ancientstation/alpha/office)
 "rxH" = (
@@ -31092,6 +31301,9 @@
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/simple_animal/hostile/carp,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -31104,6 +31316,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/lounge)
@@ -31153,6 +31368,9 @@
 	},
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "rGP" = (
@@ -31332,6 +31550,14 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/centcom)
+"rQY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/hall)
 "rRi" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-25"
@@ -31403,6 +31629,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -31665,6 +31894,9 @@
 	name = "Alpha Station Cargo Bay APC";
 	start_charge = 0;
 	auto_name = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/cargo)
@@ -32406,6 +32638,9 @@
 /obj/item/weldingtool/mini,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/iron/diagonal,
 /area/ruin/space/ancientstation/alpha/arrivals)
 "sIu" = (
@@ -32682,6 +32917,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/lounge)
 "sVI" = (
@@ -33858,6 +34096,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "tWM" = (
@@ -34307,6 +34548,7 @@
 /obj/item/shard,
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable,
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -34450,6 +34692,13 @@
 	},
 /turf/open/floor/iron,
 /area/ruin/space/ancientstation/charlie/hall)
+"uxB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/cargo)
 "uxI" = (
 /turf/closed/wall,
 /area/ruin/space/ancientstation/charlie/storage)
@@ -34529,6 +34778,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -34805,6 +35057,9 @@
 /obj/effect/decal/cleanable/glass,
 /obj/structure/table_frame,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg1"
 	},
@@ -35464,6 +35719,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "vkc" = (
@@ -35742,6 +36000,9 @@
 	name = "Alpha Station Representative's Office APC";
 	start_charge = 0;
 	auto_name = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /turf/open/floor/iron/dark/diagonal,
 /area/ruin/space/ancientstation/alpha/office)
@@ -36059,6 +36320,16 @@
 "vSc" = (
 /turf/closed/wall/rust,
 /area/ruin/space/ancientstation/beta/gravity)
+"vSU" = (
+/obj/effect/decal/cleanable/glass,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/space/ancientstation/alpha/lounge)
 "vTf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -36156,6 +36427,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer2{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
@@ -36833,6 +37107,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "wCj" = (
@@ -37003,6 +37280,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
@@ -37280,6 +37560,22 @@
 	dir = 4
 	},
 /area/syndicate_mothership/control)
+"wWu" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/iron/airless,
+/area/ruin/space/ancientstation/alpha/hall)
 "wWU" = (
 /obj/effect/turf_decal/corner/purple,
 /obj/effect/turf_decal/corner/purple{
@@ -37873,6 +38169,7 @@
 	start_charge = 0;
 	auto_name = 0
 	},
+/obj/structure/cable,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/dorms)
 "xAI" = (
@@ -38580,6 +38877,9 @@
 "yhu" = (
 /obj/effect/decal/cleanable/glass,
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless{
 	icon_state = "platingdmg2"
 	},
@@ -38621,6 +38921,9 @@
 	name = "Alpha Station Library APC";
 	start_charge = 0;
 	auto_name = 0
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
 /turf/open/floor/wood/airless{
 	icon_state = "wood-broken3"
@@ -44082,7 +44385,7 @@ cKm
 tKX
 vjO
 uFz
-vjO
+cfp
 sur
 vjO
 hLe
@@ -44596,7 +44899,7 @@ cKm
 hnf
 amf
 hSK
-vjO
+cfp
 fvY
 wkK
 cKm
@@ -45110,7 +45413,7 @@ qYI
 cVg
 caJ
 nAi
-cVg
+tXq
 wAy
 uYn
 caJ
@@ -45367,7 +45670,7 @@ wCd
 wCd
 wCd
 wCd
-vjW
+qJT
 oMe
 vVU
 jRR
@@ -45634,7 +45937,7 @@ doc
 doc
 doc
 srk
-eYG
+uGe
 caJ
 kjm
 kjm
@@ -45891,7 +46194,7 @@ lxj
 lxj
 doc
 doc
-eYG
+uGe
 caJ
 kjm
 wxo
@@ -46128,10 +46431,10 @@ eHm
 ohR
 wIQ
 kcB
-tPg
-tPg
-aBK
-cVg
+bgR
+uxB
+oKt
+fUi
 pAB
 vCP
 dRN
@@ -46405,7 +46708,7 @@ diC
 diC
 lpr
 dix
-eYG
+uGe
 cVg
 gan
 hFh
@@ -47162,7 +47465,7 @@ asu
 gXb
 acj
 jWk
-dqm
+mWl
 qxD
 vCP
 qsk
@@ -47174,7 +47477,7 @@ lpr
 uSb
 olW
 rSu
-upx
+llb
 exs
 ila
 rGN
@@ -48710,7 +49013,7 @@ ndI
 caJ
 caJ
 jIB
-caJ
+rQY
 tqM
 mGY
 xfE
@@ -49222,8 +49525,8 @@ fhZ
 fbL
 sUY
 mbO
-qss
-qss
+eYG
+vSU
 qss
 uTo
 jaA
@@ -49470,7 +49773,7 @@ tDR
 jcf
 jcf
 vlG
-tDR
+gCB
 pzK
 cVg
 acj
@@ -49727,7 +50030,7 @@ lKb
 lZL
 iYb
 tDR
-tDR
+gCB
 pzK
 cVg
 acj
@@ -50243,8 +50546,8 @@ qzy
 iWb
 sHi
 eFY
-caJ
-rVh
+att
+wWu
 hvx
 vzV
 wBw

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -12388,13 +12388,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer2,
 /mob/living/simple_animal/hostile/carp,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer4{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/cable,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer4,
 /turf/open/floor/iron/airless,
 /area/ruin/space/ancientstation/alpha/hall)
 "brq" = (
@@ -31550,14 +31548,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
 /area/centcom)
-"rQY" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/iron/airless,
-/area/ruin/space/ancientstation/alpha/hall)
 "rRi" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-25"
@@ -49013,7 +49003,7 @@ ndI
 caJ
 caJ
 jIB
-rQY
+caJ
 tqM
 mGY
 xfE


### PR DESCRIPTION
…to do so

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

wires alpha station on charlie station so you dont have to tear out the nt rep's floors to do so

## Why It's Good For The Game

pretty sure you cant fix the decals on nt rep's floors after you tear them out
also for convenience

## Changelog
:cl:
fix: Alpha Station (on Charlie Station) is now actually wired, so you don't have to tear the floors out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
